### PR TITLE
Payment tests + local testing support

### DIFF
--- a/configurations/system/backends.py
+++ b/configurations/system/backends.py
@@ -1,10 +1,14 @@
+
+from infrastructure.backend_api import *
+
+
 class Backend(object):
 
-    def __init__(self, name: str, dashboard: str, tls_verify: bool = True, skip_login: bool = False, customer_guid: str = None):
+    def __init__(self, name: str, dashboard: str, tls_verify: bool = True, login_method = LOGIN_METHOD_KEYCLOAK, customer_guid: str = None):
         self.name = name
         self.dashboard = dashboard
         self.tls_verify = tls_verify
-        self.skip_login = skip_login
+        self.login_method = login_method
         self.customer_guid = customer_guid
 
     def get_dashboard_url(self):
@@ -16,8 +20,9 @@ class Backend(object):
     def use_tls(self):
         return self.tls_verify
     
-    def do_skip_login(self):
-        return self.skip_login
+    def get_login_method(self):
+        return self.login_method
+ 
 
     def get_customer_guid(self):
         return self.customer_guid
@@ -30,10 +35,24 @@ def set_backends():
     backends.append(Backend(name='development',
                             dashboard='https://dashbe.eudev3.cyberarmorsoft.com',
                             tls_verify=False))
+    
+    # development frontEgg
+    backends.append(Backend(name='development-egg',
+                            dashboard='http://eggdashbe-dev.armosec.io',
+                            customer_guid="f5f360bb-c233-4c33-a9af-5692e7795d61",
+                            tls_verify=False,
+                            login_method=LOGIN_METHOD_FRONTEGG))
 
     # staging
     backends.append(Backend(name='staging',
                             dashboard='https://dashbe.eustage2.cyberarmorsoft.com'))
+    
+    # staging frontEgg
+    backends.append(Backend(name='staging-egg',
+                            dashboard='http://eggdashbe-stg.armosec.io',
+                            customer_guid="f5f360bb-c233-4c33-a9af-5692e7795d61",
+                            tls_verify=False,
+                            login_method=LOGIN_METHOD_FRONTEGG))
 
     # production
     backends.append(Backend(name='production',
@@ -54,7 +73,7 @@ def set_backends():
     backends.append(Backend(name='local',
                             dashboard='http://localhost:7666',
                             tls_verify=False,
-                            skip_login=True,
+                            login_method=LOGIN_METHOD_FRONTEGG,
                             customer_guid="1e3a88bf-92ce-44f8-914e-cbe71830d566"))
 
     return {backend.get_name(): backend for backend in backends}

--- a/configurations/system/backends.py
+++ b/configurations/system/backends.py
@@ -1,9 +1,11 @@
 class Backend(object):
 
-    def __init__(self, name: str, dashboard: str, tls_verify: bool = True):
+    def __init__(self, name: str, dashboard: str, tls_verify: bool = True, skip_login: bool = False, customer_guid: str = None):
         self.name = name
         self.dashboard = dashboard
         self.tls_verify = tls_verify
+        self.skip_login = skip_login
+        self.customer_guid = customer_guid
 
     def get_dashboard_url(self):
         return self.dashboard
@@ -13,6 +15,12 @@ class Backend(object):
 
     def use_tls(self):
         return self.tls_verify
+    
+    def do_skip_login(self):
+        return self.skip_login
+
+    def get_customer_guid(self):
+        return self.customer_guid
 
 
 def set_backends():
@@ -41,6 +49,13 @@ def set_backends():
     backends.append(Backend(name='dev2',
                             dashboard='https://dashbe.eudev2.cyberarmorsoft.com',
                             tls_verify=False))
+    
+    # local
+    backends.append(Backend(name='local',
+                            dashboard='http://localhost:7666',
+                            tls_verify=False,
+                            skip_login=True,
+                            customer_guid="1e3a88bf-92ce-44f8-914e-cbe71830d566"))
 
     return {backend.get_name(): backend for backend in backends}
 

--- a/configurations/system/tests.py
+++ b/configurations/system/tests.py
@@ -3,6 +3,7 @@ from systest_utils import TestUtil
 from .tests_cases import KubescapeTests, KSMicroserviceTests
 from .tests_cases.vulnerability_scanning_tests import VulnerabilityScanningTests
 from .tests_cases.ks_vulnerability_scanning_tests import KsVulnerabilityScanningTests
+from .tests_cases.payments_tests import PaymentTests
 
 
 def all_tests_names():
@@ -12,6 +13,7 @@ def all_tests_names():
     tests.extend(TestUtil.get_class_methods(VulnerabilityScanningTests))
     tests.extend(TestUtil.get_class_methods(KSMicroserviceTests))
     tests.extend(TestUtil.get_class_methods(KsVulnerabilityScanningTests))
+    tests.extend(TestUtil.get_class_methods(PaymentTests))
     return tests
 
 
@@ -25,6 +27,8 @@ def get_test(test_name):
         return KSMicroserviceTests().__getattribute__(test_name)()
     if test_name in TestUtil.get_class_methods(KsVulnerabilityScanningTests):
         return KsVulnerabilityScanningTests().__getattribute__(test_name)()
+    if test_name in TestUtil.get_class_methods(PaymentTests):
+        return PaymentTests().__getattribute__(test_name)()
 
 
 ALL_TESTS = all_tests_names()

--- a/configurations/system/tests_cases/payments_tests.py
+++ b/configurations/system/tests_cases/payments_tests.py
@@ -1,0 +1,74 @@
+import inspect
+from .structures import PaymentConfiguration
+
+
+# plan names and their price per unit in cents.
+# the name is an internal identifier which is assigned to a stripe priceId object. 
+# The price is the price in cents as defined in Stripe price object.
+EXPECTED_PRICES = [{"name":"MonthlyPriceID","price":2900},{"name":"YearlyPriceID","price":27600}]
+
+
+class PaymentTests(object):
+    '''
+    NOTE: 
+    1. In order to implement further tests, it is required to implement the ability to create a new tenant on the backend (frontEgg).
+    2. Tests depends on launching the stripe new backend APIs.
+    3. User tested must have a valid stripe customer with a valid test CC. The stripeCustomerID need to be defined in activeSubscripiton.StripeCustomerID. Example fo such a stripe test customer id is "cus_NT8XoDsp5Alqwc"
+    '''
+    
+    @staticmethod
+    def create_subscription():
+        from tests_scripts.payments.subscription import Create
+        return PaymentConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=Create,
+            expected_prices = EXPECTED_PRICES
+        )      
+
+    @staticmethod
+    def cancel_subscription():
+        from tests_scripts.payments.subscription import Cancel
+        return PaymentConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=Cancel,
+            expected_prices = EXPECTED_PRICES
+        )    
+
+    @staticmethod
+    def renew_subscription():
+        from tests_scripts.payments.subscription import Renew
+        return PaymentConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=Renew,
+            expected_prices = EXPECTED_PRICES
+
+        )    
+
+    @staticmethod
+    def stripe_checkout():
+        from tests_scripts.payments.subscription import Checkout
+        return PaymentConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=Checkout,
+            expected_prices = EXPECTED_PRICES
+
+        )   
+
+    @staticmethod
+    def stripe_billing_portal():
+        from tests_scripts.payments.portal import Portal
+        return PaymentConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=Portal
+
+        )          
+
+    @staticmethod
+    def stripe_plans():
+        from tests_scripts.payments.plans import Plans
+        return PaymentConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=Plans,
+            expected_prices = EXPECTED_PRICES
+        )    
+

--- a/configurations/system/tests_cases/payments_tests.py
+++ b/configurations/system/tests_cases/payments_tests.py
@@ -6,14 +6,17 @@ from .structures import PaymentConfiguration
 # the name is an internal identifier which is assigned to a stripe priceId object. 
 # The price is the price in cents as defined in Stripe price object.
 EXPECTED_PRICES = [{"name":"MonthlyPriceID","price":2900},{"name":"YearlyPriceID","price":27600}]
+TEST_STRIPE_CUSTOMER_ID = "cus_NT8XoDsp5Alqwc"
+
 
 
 class PaymentTests(object):
     '''
     NOTE: 
-    1. In order to implement further tests, it is required to implement the ability to create a new tenant on the backend (frontEgg).
-    2. Tests depends on launching the stripe new backend APIs.
-    3. User tested must have a valid stripe customer with a valid test CC. The stripeCustomerID need to be defined in activeSubscripiton.StripeCustomerID. Example fo such a stripe test customer id is "cus_NT8XoDsp5Alqwc"
+    1. Tests depends on launching the stripe new backend APIs.
+    2. User tested must have a valid stripe customer with a valid test CC. The stripeCustomerID need to be defined in activeSubscripiton.StripeCustomerID. Example fo such a stripe test customer id is "cus_NT8XoDsp5Alqwc"
+    3. Tests rely on Admin permissions - this can be achieved by properly configuring the AllowAnyCustomer in the backend environment.
+    4. Tests must run on frontEgg supported environments.
     '''
     
     @staticmethod
@@ -22,7 +25,8 @@ class PaymentTests(object):
         return PaymentConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=Create,
-            expected_prices = EXPECTED_PRICES
+            expected_prices = EXPECTED_PRICES,
+            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID
         )      
 
     @staticmethod
@@ -31,7 +35,9 @@ class PaymentTests(object):
         return PaymentConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=Cancel,
-            expected_prices = EXPECTED_PRICES
+            expected_prices = EXPECTED_PRICES,
+            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID
+
         )    
 
     @staticmethod
@@ -40,7 +46,9 @@ class PaymentTests(object):
         return PaymentConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=Renew,
-            expected_prices = EXPECTED_PRICES
+            expected_prices = EXPECTED_PRICES,
+            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID
+
 
         )    
 
@@ -50,8 +58,8 @@ class PaymentTests(object):
         return PaymentConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=Checkout,
-            expected_prices = EXPECTED_PRICES
-
+            expected_prices = EXPECTED_PRICES,
+            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID
         )   
 
     @staticmethod

--- a/configurations/system/tests_cases/structures.py
+++ b/configurations/system/tests_cases/structures.py
@@ -244,3 +244,35 @@ class KubescapeConfiguration(object):
         """
         return self.kwargs[item[0]] if item[0] in self.kwargs else item[1] if len(item) == 2 else self.kwargs[item]
 
+
+class PaymentConfiguration(object):
+
+    def __init__(self, name: str,
+                test_obj,
+                **kwargs):
+        # basic
+        self.name: str = name
+        self.test_obj = test_obj
+        self.kwargs: dict = kwargs
+
+    def get_arg(self, arg, default=None):
+        return self.kwargs[arg] if arg in self.kwargs else default
+
+    def get_name(self):
+        return self.name
+
+    def get_test_obj(self):
+        return self.test_obj
+
+    def __getitem__(self, item):
+        """
+        usage:
+        A(kwargs={"a": 0})
+        A["a"] -> 0
+        A[("a", 1)] -> 0
+        A["b"] -> raise exception
+        A[("b", 1)] -> 1
+        :param item: single item or tuple (item, default)
+        :return:
+        """
+        return self.kwargs[item[0]] if item[0] in self.kwargs else item[1] if len(item) == 2 else self.kwargs[item]

--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -70,11 +70,11 @@ class ControlPanelAPI(object):
         res = self.get(API_STRIPE_BILLING_PORTAL, params={"customerGUID": self.customer_guid})
         return res
 
-    def stripe_checkout(self,priceId: str) -> requests.Response:
+    def stripe_checkout(self,priceID: str) -> requests.Response:
         res = self.post(API_STRIPE_CHECKOUT, 
                         params={"customerGUID": self.customer_guid},
-                        data={
-                            "priceId": priceId
+                        json={
+                            "priceID": priceID
                         },)
         return res
     
@@ -83,13 +83,13 @@ class ControlPanelAPI(object):
         return res
 
     
-    def create_subscription(self, priceId: str)-> requests.Response:
+    def create_subscription(self, priceID: str)-> requests.Response:
 
         res = self.post(
             API_TENANT_SUBSCRIPTION_CREATE,
             params={"customerGUID": self.customer_guid},
-            data={
-                "priceId": priceId
+            json={
+                "priceID": priceID
             },
         )
         return res

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,12 @@
 | `vulnerability_scanning_trigger_scan_public_registry_excluded` | helm-chart |                                                                        | kubevuln, backend             |
 | `vulnerability_scanning_trigger_scan_private_quay_registry`    | helm-chart |                                                                        | kubevuln, backend             |
 | `vulnerability_scanning_triggering_with_cron_job`              | helm-chart |                                                                        | kubevuln, backend             |
+| `create_subscription`              | payment |                                                                        | stripe, backend             |
+| `cancel_subscription`              | payment |                                                                        | stripe, backend             |
+| `renew_subscription`              | payment |                                                                        | stripe, backend             |
+| `stripe_checkout`              | payment |                                                                        | stripe, backend             |
+| `stripe_billing_portal`              | payment |                                                                        | stripe, backend             |
+| `stripe_plans`              | payment |                                                                        | stripe, backend             |
 
 
 ### Install:

--- a/test_driver.py
+++ b/test_driver.py
@@ -43,7 +43,7 @@ class TestDriver(object):
                                   client_id=self.credentials_obj.get_client_id(),
                                   secret_key=self.credentials_obj.get_secret_key(),
                                   url=self.backend_obj.get_dashboard_url(),
-                                  skip_login=self.backend_obj.do_skip_login(),
+                                  login_method=self.backend_obj.get_login_method(),
                                   customer_guid=self.backend_obj.get_customer_guid())
 
         status = statics.FAILURE

--- a/test_driver.py
+++ b/test_driver.py
@@ -42,7 +42,9 @@ class TestDriver(object):
                                   customer=self.credentials_obj.get_customer(),
                                   client_id=self.credentials_obj.get_client_id(),
                                   secret_key=self.credentials_obj.get_secret_key(),
-                                  url=self.backend_obj.get_dashboard_url())
+                                  url=self.backend_obj.get_dashboard_url(),
+                                  skip_login=self.backend_obj.do_skip_login(),
+                                  customer_guid=self.backend_obj.get_customer_guid())
 
         status = statics.FAILURE
         summary = ""

--- a/tests_scripts/payments/base_payment.py
+++ b/tests_scripts/payments/base_payment.py
@@ -1,0 +1,51 @@
+from tests_scripts import base_test
+import requests
+from  http import client
+
+payingCustomer = "paying"
+freeCustomer    = "free"
+trialCustomer   = "trial"
+blockedCustomer = "blocked"
+
+
+class BasePayment(base_test.BaseTest):
+        
+
+    def __init__(self, test_obj=None, backend=None, test_driver=None):
+        super().__init__(test_driver=test_driver, test_obj=test_obj, backend=backend)
+    
+    @staticmethod
+    def http_status_ok(http_status: int):
+        assert http_status == client.OK
+
+
+    def tenants_subscription_active(self, activeSubscription: str):
+        assert activeSubscription["licenseType"] == "Team", f"expected license type 'Team', found '{activeSubscription['licenseType']}'"
+        assert activeSubscription["subscriptionStatus"] == "active", f"expected subscription status 'active', found '{activeSubscription['subscriptionStatus']}'"
+
+    def tenants_subscription_canceled(self, activeSubscription: str):
+        pass
+
+    def tenants_access_state_paying(self, accessState: str):
+        assert accessState == payingCustomer, f"expected access state '{payingCustomer}', found '{accessState}'"
+
+    def tenants_access_state_free(self, accessState: str):
+        assert accessState == freeCustomer, f"expected access state '{freeCustomer}', found '{accessState}'"
+
+    def create_new_tenant(self) -> requests.Response:
+        '''
+            Need to implement on backend creating new tenant
+
+        '''
+        pass
+
+    def delete_tenant(self) -> requests.Response:
+        '''
+            Need to implement on backend creating new tenant
+
+        '''        
+        pass
+
+    def cleanup(self, **kwargs):
+        self.delete_tenant()
+        return super().cleanup(**kwargs)

--- a/tests_scripts/payments/base_stripe.py
+++ b/tests_scripts/payments/base_stripe.py
@@ -65,7 +65,7 @@ class BaseStripe(BasePayment):
 
     def stripe_billing_portal(self) -> requests.Response:
         response = self.backend.stripe_billing_portal()
-        assert response.status_code == client.OK, f"stripe billing portal failed. Make check sure 'PortalReturnPath' is well defined in the backend config"
+        assert response.status_code == client.CREATED, f"stripe billing portal failed. Make check sure 'PortalReturnPath' is well defined in the backend config"
         return response
 
     

--- a/tests_scripts/payments/base_stripe.py
+++ b/tests_scripts/payments/base_stripe.py
@@ -7,6 +7,7 @@ from  http import client
 
 from tests_scripts.payments.base_payment import BasePayment
 
+WEBHOOK_SLEEP = 1
 
 class BaseStripe(BasePayment):
         
@@ -16,6 +17,7 @@ class BaseStripe(BasePayment):
 
         # expects a list of dict, for each item in list "name" is the name of the plan on our internal systems, "price" is the price in cents as expected to be defined in Stripe
         self.expected_prices = self.test_obj.get_arg("expected_prices")
+        self.test_stripe_customer_id = self.test_obj.get_arg("test_stripe_customer_id")
     
     def cleanup(self, **kwargs):
         super().cleanup(**kwargs)
@@ -33,27 +35,27 @@ class BaseStripe(BasePayment):
         super().tenants_subscription_canceled(activeSubscription)
         assert activeSubscription["cancelAtPeriodEnd"] == True, "cancelAtPeriodEnd is False"
 
-    def get_tenant_details(self) -> requests.Response:
-        response = self.backend.get_tenant_details()
+    def get_tenant_details(self, tenantID: str) -> requests.Response:
+        response = self.backend.get_tenant_details(tenantID)
         assert response.status_code == client.OK, f"get tenant details failed"
         return response
     
-    def create_subscription(self, priceID) -> requests.Response:
+    def create_subscription(self, priceID: str, stripeCustomerID :str, tenantID: str) -> requests.Response:
         try:
-            response = self.backend.create_subscription(priceID)
+            response = self.backend.create_subscription(priceID, stripeCustomerID, tenantID)
         except Exception as e:
             assert False, f"create subscription failed with priceID: {priceID} and error: {e}"
         assert response.status_code == client.OK, f"stripe checkout failed with priceID: {priceID}"
         return response
     
         
-    def cancel_subscription(self) -> requests.Response:
-        response = self.backend.cancel_subscription()
+    def cancel_subscription(self, tenantID: str) -> requests.Response:
+        response = self.backend.cancel_subscription(tenantID)
         assert response.status_code == client.OK, f"cancel subscription failed"
         return response
     
-    def renew_subscription(self) -> requests.Response:
-        response = self.backend.renew_subscription()
+    def renew_subscription(self, tenantID: str) -> requests.Response:
+        response = self.backend.renew_subscription(tenantID)
         assert response.status_code == client.OK, f"renew subscription failed"
         return response
 
@@ -65,7 +67,7 @@ class BaseStripe(BasePayment):
 
     def stripe_billing_portal(self) -> requests.Response:
         response = self.backend.stripe_billing_portal()
-        assert response.status_code == client.CREATED, f"stripe billing portal failed. Make check sure 'PortalReturnPath' is well defined in the backend config"
+        assert response.status_code == client.CREATED, f"stripe billing portal failed. Make sure that 'PortalReturnPath' is well defined in the backend config"
         return response
 
     

--- a/tests_scripts/payments/base_stripe.py
+++ b/tests_scripts/payments/base_stripe.py
@@ -42,8 +42,8 @@ class BaseStripe(BasePayment):
         try:
             response = self.backend.create_subscription(priceID)
         except Exception as e:
-            assert False, f"create subscription failed with priceId: {priceID} and error: {e}"
-        assert response.status_code == client.OK, f"stripe checkout failed with priceId: {priceID}"
+            assert False, f"create subscription failed with priceID: {priceID} and error: {e}"
+        assert response.status_code == client.OK, f"stripe checkout failed with priceID: {priceID}"
         return response
     
         
@@ -60,7 +60,7 @@ class BaseStripe(BasePayment):
 
     def stripe_checkout(self, priceID) -> requests.Response:
         response = self.backend.stripe_checkout(priceID)
-        assert response.status_code == client.OK, f"stripe checkout failed with priceId: {priceID}"
+        assert response.status_code == client.CREATED, f"stripe checkout failed with priceID: {priceID}"
         return response
 
     def stripe_billing_portal(self) -> requests.Response:

--- a/tests_scripts/payments/base_stripe.py
+++ b/tests_scripts/payments/base_stripe.py
@@ -1,0 +1,71 @@
+
+ 
+from configurations.system.tests_cases.structures import TestConfiguration
+from systest_utils import statics
+import requests
+from  http import client
+
+from tests_scripts.payments.base_payment import BasePayment
+
+
+class BaseStripe(BasePayment):
+        
+
+    def __init__(self, test_obj :TestConfiguration =None, backend=None, test_driver=None):
+        super().__init__(test_driver=test_driver, test_obj=test_obj, backend=backend)
+
+        # expects a list of dict, for each item in list "name" is the name of the plan on our internal systems, "price" is the price in cents as expected to be defined in Stripe
+        self.expected_prices = self.test_obj.get_arg("expected_prices")
+    
+    def cleanup(self, **kwargs):
+        super().cleanup(**kwargs)
+        return statics.SUCCESS, ""
+    
+
+    def tenants_subscription_active(self, activeSubscription: str):
+        super().tenants_subscription_active(activeSubscription)
+        assert activeSubscription["cancelAtPeriodEnd"] == False, "cancelAtPeriodEnd is True"
+        assert activeSubscription["stripeSubscriptionID"] != "", "stripeSubscriptionID is empty"
+        assert activeSubscription["stripeCustomerID"] != "", "stripeCustomerID is empty"
+
+
+    def tenants_subscription_canceled(self, activeSubscription: str):
+        super().tenants_subscription_canceled(activeSubscription)
+        assert activeSubscription["cancelAtPeriodEnd"] == True, "cancelAtPeriodEnd is False"
+
+    def get_tenant_details(self) -> requests.Response:
+        response = self.backend.get_tenant_details()
+        assert response.status_code == client.OK, f"get tenant details failed"
+        return response
+    
+    def create_subscription(self, priceID) -> requests.Response:
+        try:
+            response = self.backend.create_subscription(priceID)
+        except Exception as e:
+            assert False, f"create subscription failed with priceId: {priceID} and error: {e}"
+        assert response.status_code == client.OK, f"stripe checkout failed with priceId: {priceID}"
+        return response
+    
+        
+    def cancel_subscription(self) -> requests.Response:
+        response = self.backend.cancel_subscription()
+        assert response.status_code == client.OK, f"cancel subscription failed"
+        return response
+    
+    def renew_subscription(self) -> requests.Response:
+        response = self.backend.renew_subscription()
+        assert response.status_code == client.OK, f"renew subscription failed"
+        return response
+
+
+    def stripe_checkout(self, priceID) -> requests.Response:
+        response = self.backend.stripe_checkout(priceID)
+        assert response.status_code == client.OK, f"stripe checkout failed with priceId: {priceID}"
+        return response
+
+    def stripe_billing_portal(self) -> requests.Response:
+        response = self.backend.stripe_billing_portal()
+        assert response.status_code == client.OK, f"stripe billing portal failed. Make check sure 'PortalReturnPath' is well defined in the backend config"
+        return response
+
+    

--- a/tests_scripts/payments/plans.py
+++ b/tests_scripts/payments/plans.py
@@ -1,0 +1,27 @@
+from .base_stripe import BaseStripe
+from time import sleep
+
+
+class Plans(BaseStripe):
+    '''
+        check that the plans are configured correctly on backend, and have the expected prices on process.
+        result is compared to 'self.expected_prices'
+    '''
+    def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
+        super(Plans, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
+    
+    def start(self):
+        response = self.backend.get_stripe_plans()
+        assert response.status_code == 200, f"expected status code 200, found {response.status_code}. Make sure you have a valid stripe secret key and priceIdsMap is well configured"
+
+        for plan in response.json():
+            name = plan["name"]
+            price = plan["price"]
+            assert name in [price["name"] for price in self.expected_prices], f"price plan '{name}' not found in response"
+            expected_price = [price["price"] for price in self.expected_prices if price["name"] == name][0]
+            assert price == expected_price, f"expected price of plan '{name}' = '{expected_price}', found '{price}' "
+
+        return self.cleanup()
+
+
+

--- a/tests_scripts/payments/portal.py
+++ b/tests_scripts/payments/portal.py
@@ -1,0 +1,25 @@
+from configurations.system.tests_cases.structures import TestConfiguration
+from systest_utils import Logger
+from .base_stripe import BaseStripe
+from time import sleep
+
+
+class Portal(BaseStripe):
+    '''
+        check stripe customer billing portal page - if returns 200 is means that the page is up and running
+    '''
+    def __init__(self, test_obj: TestConfiguration = None, backend=None, test_driver=None):
+        super(Portal, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
+
+    def start(self):
+        Logger.logger.info("Create new tenant")
+        self.create_new_tenant()
+
+        Logger.logger.info("Get Tenants details")
+        response = self.get_tenant_details()
+
+        Logger.logger.info("Stage 1: Go to stripe billing portal")
+
+        response = self.stripe_billing_portal()
+
+        return self.cleanup()

--- a/tests_scripts/payments/subscription.py
+++ b/tests_scripts/payments/subscription.py
@@ -1,0 +1,129 @@
+
+from configurations.system.tests_cases.structures import TestConfiguration
+from systest_utils import Logger
+from .base_stripe import BaseStripe
+from time import sleep
+
+
+
+class Checkout(BaseStripe):
+    '''
+        check stripe checkout page - if returns 200 is means that the page is up and running
+    '''
+
+    def __init__(self, test_obj: TestConfiguration = None, backend=None, test_driver=None):
+        super(Checkout, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
+
+    def start(self):
+        Logger.logger.info("Create new tenant")
+        self.create_new_tenant()
+
+        Logger.logger.info("Stage 1: Go to stripe checkout page for each price")
+
+        for price in self.expected_prices:
+            response = self.stripe_checkout(price["name"])
+
+        return self.cleanup()
+
+class Create(BaseStripe):
+    '''
+        check subscription is created successfully and expected data is updated in tenant details (via webhook)
+    '''
+
+    def __init__(self, test_obj: TestConfiguration = None, backend=None, test_driver=None):
+        super(Create, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
+
+    def start(self):
+        Logger.logger.info("Create new tenant")
+        self.create_new_tenant()
+
+        Logger.logger.info("Get Tenants details")
+        response = self.get_tenant_details()
+
+        Logger.logger.info("Stage 1: create a subscription")
+        response = self.create_subscription(self.expected_prices[0]["name"])
+        stripeSubscriptionID = response.json()["id"]
+
+        Logger.logger.info("Stage 2: Validate tenants details after subscription creation")
+
+        # sleep to let webhook update tenant details
+        sleep(2)
+        response = self.get_tenant_details()
+        assert response.json().get("activeSubscription", {}).get("stripeSubscriptionID", {}) == stripeSubscriptionID, "stripeSubscriptionID is not updated"
+
+        Logger.logger.info("Stage 3: Validate tenants subscription is active")
+        self.tenants_subscription_active(response.json().get("activeSubscription", {}))
+
+        return self.cleanup()
+    
+
+
+class Cancel(BaseStripe):
+
+    '''
+        check subscription is canceled successfully and expected data is updated in tenant details (via webhook)
+    '''
+    def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
+        super(Cancel, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
+
+    def start(self):
+        Logger.logger.info("Create new tenant")
+        self.create_new_tenant()
+
+        Logger.logger.info("Get Tenants details")
+        response = self.get_tenant_details()
+
+
+        Logger.logger.info("Stage 1: create a subscription")
+        response = self.create_subscription(self.expected_prices[0]["name"])
+        # sleep to let webhook update tenant details
+        sleep(2)
+
+        Logger.logger.info("Stage 2: cancel a subscription")
+        response = self.cancel_subscription()
+
+        Logger.logger.info("Stage 3: Validate tenants details after subscription canceled")
+        sleep(2)
+        response = self.get_tenant_details()
+        self.tenants_subscription_canceled(response.json().get("activeSubscription", {}))
+
+        return self.cleanup()
+    
+
+class Renew(BaseStripe):
+
+    '''
+        check subscription is renewed successfully and expected data is updated in tenant details (via webhook)
+    '''
+
+    def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
+        super(Renew, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
+
+    def start(self):
+        Logger.logger.info("Create new tenant")
+        self.create_new_tenant()
+
+        Logger.logger.info("Stage 1: create a subscription")
+        response = self.create_subscription(self.expected_prices[0]["name"])
+        self.http_status_ok(response.status_code)
+        # sleep to let webhook update tenant details
+        sleep(2)
+
+        Logger.logger.info("Stage 2: cancel a subscription")
+        response = self.cancel_subscription()
+
+        Logger.logger.info("Stage 3: Validate tenants details after subscription canceled")
+        sleep(2)
+        response = self.get_tenant_details()
+        self.tenants_subscription_canceled(response.json().get("activeSubscription", {}))
+        self.tenants_access_state_paying(response.json().get("customerAccessStatus", {}))
+
+        Logger.logger.info("Stage 4: renew a subscription")
+        response = self.renew_subscription()
+        
+        Logger.logger.info("Stage 5: Validate tenants details after subscription renewed")
+        sleep(2)
+        response = self.get_tenant_details()
+        self.tenants_subscription_active(response.json().get("activeSubscription", {}))
+
+        return self.cleanup()

--- a/tests_scripts/payments/subscription.py
+++ b/tests_scripts/payments/subscription.py
@@ -15,8 +15,9 @@ class Checkout(BaseStripe):
         super(Checkout, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
 
     def start(self):
-        Logger.logger.info("Create new tenant")
-        self.create_new_tenant()
+        # TODO: Implement on backend creating new tenant
+        # Logger.logger.info("Create new tenant")
+        # self.create_new_tenant()
 
         Logger.logger.info("Stage 1: Go to stripe checkout page for each price")
 
@@ -34,8 +35,9 @@ class Create(BaseStripe):
         super(Create, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
 
     def start(self):
-        Logger.logger.info("Create new tenant")
-        self.create_new_tenant()
+        # TODO: Implement on backend creating new tenant
+        # Logger.logger.info("Create new tenant")
+        # self.create_new_tenant()
 
         Logger.logger.info("Get Tenants details")
         response = self.get_tenant_details()
@@ -67,8 +69,9 @@ class Cancel(BaseStripe):
         super(Cancel, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
 
     def start(self):
-        Logger.logger.info("Create new tenant")
-        self.create_new_tenant()
+        # TODO: Implement on backend creating new tenant
+        # Logger.logger.info("Create new tenant")
+        # self.create_new_tenant()
 
         Logger.logger.info("Get Tenants details")
         response = self.get_tenant_details()
@@ -100,8 +103,9 @@ class Renew(BaseStripe):
         super(Renew, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
 
     def start(self):
-        Logger.logger.info("Create new tenant")
-        self.create_new_tenant()
+        # TODO: Implement on backend creating new tenant
+        # Logger.logger.info("Create new tenant")
+        # self.create_new_tenant()
 
         Logger.logger.info("Stage 1: create a subscription")
         response = self.create_subscription(self.expected_prices[0]["name"])


### PR DESCRIPTION
1. Support in local environments testing.
2. Infrastructure for payment testing. 
3. Implementation of basic payment tests - see in readme test cases related to the "payment" category. 

**Notes:** 
- Using payment tests depends on releasing payment ph1 APIs on backend.
- Additional payment tests may require a solution of either having the ability of creating new users on the different environments dynamically, or pre-configured users for each environment.