### PR TITLE
test: host scanner system test

### DIFF
--- a/configurations/system/tests_cases/kubescape_tests.py
+++ b/configurations/system/tests_cases/kubescape_tests.py
@@ -231,3 +231,15 @@ class KubescapeTests(object):
             submit=False,
             account=False,
         )
+
+    @staticmethod
+    def host_scanner_with_hostsensorrule():
+        from tests_scripts.kubescape.scan import HostScanner
+        return KubescapeConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=HostScanner,
+            policy_scope='control',
+            policy_name='C-0052,C-0069,C-0070,C-0092,C-0093,C-0094,C-0095,C-0096,C-0097,C-0098,C-0099,C-0100',
+            submit=False,
+            account=False,
+        )

--- a/create_env.sh
+++ b/create_env.sh
@@ -2,8 +2,8 @@
 
 echo "user: $USER"
 echo "path: $PATH"
-python3.8 --version
-pip3.8 --version
+python3 --version
+pip3 --version
 docker --version
 
 #kubectl version --short
@@ -23,7 +23,7 @@ SCRIPTPATH="$(
 
 echo "Path: ${SCRIPTPATH}"
 
-if ! python3.8 -m venv systests_python_env; then
+if ! python3 -m venv systests_python_env; then
   echo "Failed to create python environment"
   exit 1
 fi
@@ -39,12 +39,12 @@ if [ "$(uname)" == "Darwin" ]; then
   brew install openssl
   brew link openssl --force
   source systests_python_env/bin/activate
-  LDFLAGS="-L$(brew --prefix openssl@1.1)/lib" CFLAGS="-I$(brew --prefix openssl@1.1)/include" pip3.8 install -r requirements.txt
+  LDFLAGS="-L$(brew --prefix openssl@1.1)/lib" CFLAGS="-I$(brew --prefix openssl@1.1)/include" pip3 install -r requirements.txt
   brew unlink openssl
 else
   echo "OS: Linux"
   . systests_python_env/bin/activate
-  pip3.8 install -r requirements.txt
+  pip3 install -r requirements.txt
   wget https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.sh -O cmake.sh
   sudo sh cmake.sh --prefix=/usr/local/ --exclude-subdir
 fi

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,10 @@
 | `scan_repository_from_url_and_submit_to_backend`               | kubescape  | scan repository from URL and test results against the backend          | kubescape, backend            |
 | `scan_with_exception_to_backend`                               | kubescape  | scan framework NSA with exception and test results against the backend | kubescape, backend            | 
 | `scan_with_custom_framework`                                   | kubescape  | scan custom framework and test results against the backend             | kubescape, backend            |
-| `scan_compliance_score`                                   | kubescape  | scan and test compliance score from kubescape report and from backend             | kubescape, backend            |
+| `scan_compliance_score`                                        | kubescape  | scan and test compliance score from kubescape report and from backend  | kubescape, backend            |
 | `scan_customer_configuration`                                  | kubescape  | scan controls with customer configuration                              | kubescape, backend            |
 | `host_scanner`                                                 | kubescape  | scan with host scanner                                                 | kubescape                     |
+| `host_scanner_with_hostsensorrule`                             | kubescape  | scan with host scanner using rules with `hostSensorRule: true`         | kubescape                     |
 | `vulnerability_scanning`                                       | helm-chart |                                                                        | kubevuln, backend             |
 | `vulnerability_scanning_trigger_scan_on_new_image`             | helm-chart |                                                                        | kubevuln, backend             |
 | `ks_microservice_ns_creation`                                  | helm-chart |                                                                        | in-cluster kubescape, backend |


### PR DESCRIPTION
This PR adds a dedicated test to test `host-scanner` (`:test` tag) integration with `kubescape`.