### PR TITLE
Test tenants management

### DIFF
--- a/configurations/system/tests_cases/payments_tests.py
+++ b/configurations/system/tests_cases/payments_tests.py
@@ -26,7 +26,8 @@ class PaymentTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=StripeWebhook,
             expected_prices = EXPECTED_PRICES,
-            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID
+            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID,
+            create_test_tenant = True
 
 
         )    
@@ -38,7 +39,9 @@ class PaymentTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=Checkout,
             expected_prices = EXPECTED_PRICES,
-            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID
+            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID,
+            create_test_tenant = True
+
         )   
 
     @staticmethod
@@ -48,7 +51,9 @@ class PaymentTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=Portal,
             expected_prices = EXPECTED_PRICES,
-            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID
+            test_stripe_customer_id = TEST_STRIPE_CUSTOMER_ID,
+            create_test_tenant = True
+
         )          
 
     @staticmethod
@@ -57,6 +62,8 @@ class PaymentTests(object):
         return PaymentConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=Plans,
-            expected_prices = EXPECTED_PRICES
+            expected_prices = EXPECTED_PRICES,
+            create_test_tenant = True
+
         )    
 

--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -291,7 +291,7 @@ class ControlPanelAPI(object):
 
 
         res = self.delete(API_ADMIN_TENANTS, json={"tenantsIds": [tenant_id]})
-        assert res.status_code == client.OK, f"delete tenant failed: {res.status_code} {res.text}"
+        assert res.status_code == client.OK, f"delete tenant failed {tenant_id}: {res.status_code} {res.text}"
         return res
 
     

--- a/jenkins_files/Jenkinsfile-helm-ks-be-test.groovy
+++ b/jenkins_files/Jenkinsfile-helm-ks-be-test.groovy
@@ -2,6 +2,7 @@ def backend = "${env.BACKEND}"
 def helm_branch = "${env.HELM_BRANCH}"
 def ks_branch = "${env.KS_BRANCH}"
 
+
 def delete_test_tenant
 
 if (env.DELETE_TEST_TENANT) {
@@ -9,6 +10,15 @@ if (env.DELETE_TEST_TENANT) {
 } else {
     delete_test_tenant = "ALWAYS"
 }
+
+
+
+// def delete_test_tenant = "${env.hasProperty('DELETE_TEST_TENANT')}" ? "${env.DELETE_TEST_TENANT}" : "ALWAYS"
+
+
+
+//ks_microservice_create_2_cronjob_mitre_and_nsa
+//vulnerability_scanning
 
 
 // Add kubescape-CLI and kubescape-HELM tests that use the BE API

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@
 | `host_scanner`                                                 | kubescape  | scan with host scanner                                                 | kubescape                     |
 | `host_scanner_with_hostsensorrule`                             | kubescape  | scan with host scanner using rules with `hostSensorRule: true`         | kubescape                     |
 | `vulnerability_scanning`                                       | helm-chart |                                                                        | kubevuln, backend             |
+| `vulnerability_scanning_proxy`                                       | helm-chart |                                                                        | kubevuln, backend             |
 | `vulnerability_scanning_trigger_scan_on_new_image`             | helm-chart |                                                                        | kubevuln, backend             |
 | `ks_microservice_ns_creation`                                  | helm-chart |                                                                        | in-cluster kubescape, backend |
 | `ks_microservice_on_demand`                                    | helm-chart |                                                                        | in-cluster kubescape, backend |
@@ -30,6 +31,7 @@
 | `ks_microservice_update_cronjob_schedule`                      | helm-chart |                                                                        | in-cluster kubescape, backend |
 | `ks_microservice_delete_cronjob`                               | helm-chart |                                                                        | in-cluster kubescape, backend |
 | `ks_microservice_create_2_cronjob_mitre_and_nsa`               | helm-chart |                                                                        | in-cluster kubescape, backend |
+`ks_microservice_create_2_cronjob_mitre_and_nsa_proxy`               | helm-chart |                                                                        | in-cluster kubescape, backend |
 | `vulnerability_scanning_trigger_scan_public_registry`          | helm-chart |                                                                        | kubevuln, backend             |
 | `vulnerability_scanning_trigger_scan_public_registry_excluded` | helm-chart |                                                                        | kubevuln, backend             |
 | `vulnerability_scanning_trigger_scan_private_quay_registry`    | helm-chart |                                                                        | kubevuln, backend             |
@@ -80,6 +82,10 @@ Add to environment the following values to connect to the backend:
 | `-temp`/ `--temp-dir`                  | temp dir location, make sure the test has r/w privileges                                                                               |                                        |      ./temp      |
 | `-lcn`/ `--leave-cyberarmor-namespace` | Leave CyberArmor namespace after test is done                                                                                          |                                        |      False       |
 | -h                                     | Help                                                                                                                                   | 
+| `--delete_test_tenant` | When to delete test tenant, if configured for test                                                                                          |  ALWAYS(default), TEST_PASSED, NEVER                                       |      False       |
+
+
+
 
 #### kwargs options
 

--- a/systest-cli.py
+++ b/systest-cli.py
@@ -31,6 +31,9 @@ def input_parser():
     parser.add_argument("--logger", choices=["DEBUG", "INFO", "WARNING", "ERROR"], help="logger level", default="DEBUG",
                         dest="logger_level")
 
+    parser.add_argument("--delete_test_tenant", choices=["ALWAYS", "TEST_PASSED", "NEVER"], help="when to delete test tenant", default="ALWAYS",
+                        dest="delete_test_tenant")
+    
     parser.add_argument("-f", "--fresh", action="store_true", dest="fresh", default=False,
                         help="refresh local docker images, build new ones (and remove the old ones).")
 

--- a/test_driver.py
+++ b/test_driver.py
@@ -44,7 +44,8 @@ class TestDriver(object):
                                   secret_key=self.credentials_obj.get_secret_key(),
                                   url=self.backend_obj.get_dashboard_url(),
                                   auth_url=self.backend_obj.get_auth_url(),
-                                  login_method=self.backend_obj.get_login_method())
+                                  login_method=self.backend_obj.get_login_method(),
+                                  customer_guid=self.backend_obj.get_customer_guid())
 
         status = statics.FAILURE
         summary = ""
@@ -73,7 +74,18 @@ class TestDriver(object):
             status, summary = test_class_obj.start()
         except Exception as ex:
             status = statics.FAILURE
-            _, _ = test_class_obj.cleanup()
+            test_class_obj.failed()
+            _, _, tb = sys.exc_info()
+            function_name = tb.tb_frame.f_code.co_name
+
+            if function_name != "cleanup":
+                try:
+                    _, _ = test_class_obj.cleanup()
+                except Exception as e:
+                    Logger.logger.info("Failed to cleanup test")
+                    Logger.logger.error("error: {}".format(traceback.print_exc()))
+            else:
+                Logger.logger.info("Failed to cleanup test")
             summary = ex
             Logger.logger.error("error: {}".format(traceback.print_exc()))
         finally:

--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -58,14 +58,10 @@ class BaseHelm(BaseK8S):
             except:
                 pass
 
-        if self.remove_cluster_from_backend:
+        if self.remove_cluster_from_backend and not self.cluster_deleted:
             TestUtil.sleep(150, "Waiting for aggregation to end")
-            try:
-                cluster_name = self.kubernetes_obj.get_cluster_name()
-                Logger.logger.info("Deleting cluster '{}' from backend".format(cluster_name))
-                self.backend.delete_cluster(cluster_name=cluster_name)
-            except:
-                pass
+            self.cluster_deleted = self.delete_cluster_from_backend()
+
         return super().cleanup(**kwargs)
 
     def display_armo_system_logs(self, level=Logger.logger.debug):

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -49,8 +49,6 @@ class ScanWithKubescapeHelmChart(BaseHelm, BaseKubescape):
 
         self.test_helm_chart_tesults(report_guid=report_guid)
 
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
         return self.cleanup()
 
 
@@ -86,8 +84,6 @@ class ScanWithKubescapeAsServiceTest(BaseHelm, BaseKubescape):
 
         self.test_scan_jobs(port=statics.KS_PORT_FORWARD)
 
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
         return self.cleanup()
 
     def test_scan_jobs(self, port):

--- a/tests_scripts/helm/vulnerability_scanning.py
+++ b/tests_scripts/helm/vulnerability_scanning.py
@@ -34,39 +34,41 @@ class VulnerabilityScanningProxy(BaseVulnerabilityScanning):
     def start(self):
         cluster, namespace = self.setup(apply_services=False)
 
-        Logger.logger.info('2. apply cluster resources')
 
-        Logger.logger.info('2.1 apply services')
+        Logger.logger.info('1. apply cluster resources')
+
+
+        Logger.logger.info('1.1 apply services')
         self.apply_directory(path=self.test_obj[("services", None)], namespace=namespace)
 
-        Logger.logger.info('2.2 apply config-maps')
+        Logger.logger.info('1.2 apply config-maps')
         self.apply_directory(path=self.test_obj[("config_maps", None)], namespace=namespace)
 
-        Logger.logger.info('2.3 apply workloads')
+        Logger.logger.info('1.3 apply workloads')
         workload_objs: list = self.apply_directory(path=self.test_obj["deployments"], namespace=namespace)
         wlids = self.get_wlid(workload=workload_objs, namespace=namespace, cluster=cluster)
 
-        Logger.logger.info('3. verify all pods are running')
+        Logger.logger.info('2. verify all pods are running')
         self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
 
         since_time = datetime.now(timezone.utc).astimezone().isoformat()
 
-        Logger.logger.info('4. install armo helm-chart')
+        Logger.logger.info('3. install armo helm-chart')
         self.add_and_upgrade_armo_to_repo()
         self.install_armo_helm_chart()
 
-        Logger.logger.info('4.1 verify helm installation')
+        Logger.logger.info('3.1 verify helm installation')
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME)
 
    
-        Logger.logger.info('5. Get the scan result from Backend')
+        Logger.logger.info('4. Get the scan result from Backend')
         # In order to check proxy it is enough to check that at least one pod is updated on backend.
         expected_number_of_pods = 1
         be_summary, _ = self.wait_for_report(timeout=400, report_type=self.backend.get_scan_results_sum_summary,
                                              namespace=namespace, since_time=since_time,
                                              expected_results=expected_number_of_pods)
         self.test_total_is_rce_count(be_summary)
-        Logger.logger.info('6. Test no errors in results')
+        Logger.logger.info('5. Test no errors in results')
         self.test_no_errors_in_scan_result(be_summary)
 
         self.uninstall_armo_helm_chart()
@@ -163,11 +165,7 @@ class VulnerabilityScanning(BaseVulnerabilityScanning):
 
         Logger.logger.info('delete armo namespace')
         self.uninstall_armo_helm_chart()
-        TestUtil.sleep(150, "Waiting for aggregation to end")
-
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
-        self.test_cluster_deleted(since_time=since_time)
+        # TestUtil.sleep(150, "Waiting for aggregation to end")
 
         return self.cleanup()
 
@@ -750,8 +748,6 @@ class VulnerabilityScanningTriggeringWithCronJob(BaseVulnerabilityScanning):
         Logger.logger.info("Test delete vuln-scan cronjob")
         self.test_delete_vuln_scan_cronjob(cron_job=cj)
 
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
         return self.cleanup()
 
 
@@ -805,9 +801,6 @@ class RegistryScanningTriggeringWithCronJob(VulnerabilityScanningRegistry):
         Logger.logger.info("Test delete registry-scan cronjob - deprecated API")
         self.test_delete_registry_scan_cronjob_deprecated(cron_job=cj)
 
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
-        time.sleep(180)
 
         return self.cleanup()
 

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -82,6 +82,7 @@ class BaseKubescape(BaseK8S):
         self.kubescape_exec = self.test_driver.kwargs.get("kubescape", None)
         self.environment = '' if self.test_driver.backend_obj.get_name() == "production" else self.test_driver.backend_obj.get_name()
         self.host_scan_yaml = self.test_driver.kwargs.get("host_scan_yaml", None)
+        self.remove_cluster_from_backend = False
 
     def default_scan(self, **kwargs):
         res_file = self.get_default_results_file()
@@ -89,7 +90,9 @@ class BaseKubescape(BaseK8S):
         return self.load_results(results_file=res_file)
 
     def cleanup(self, **kwargs):
-
+        if self.remove_cluster_from_backend and not self.cluster_deleted:
+            TestUtil.sleep(150, "Waiting for aggregation to end")
+            self.cluster_deleted = self.delete_cluster_from_backend()
         super().cleanup(**kwargs)
         return statics.SUCCESS, ""
 

--- a/tests_scripts/kubescape/scan.py
+++ b/tests_scripts/kubescape/scan.py
@@ -146,8 +146,6 @@ class ScanComplianceScore(BaseKubescape):
             self.test_compliance_score_in_clusters_overtime(cluster_name=self.kubernetes_obj.get_cluster_name(),
                                                             framework_name=framework_report[_CLI_NAME_FIELD],framework_report=framework_report)
         
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
 
         return self.cleanup()
 
@@ -206,8 +204,6 @@ class ScanAndSubmitToBackend(BaseKubescape):
                              framework_name=(self.test_obj.get_arg("policy_name")).upper(),
                              old_report_guid=old_report_guid)
 
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
         return self.cleanup()
 
 
@@ -359,8 +355,6 @@ class ScanWithExceptionToBackend(BaseKubescape):
                                         framework_name=self.test_obj.get_arg("policy_name").upper(),namespace="system-test")
 
 
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
         return self.cleanup()
 
     def cleanup(self):
@@ -417,8 +411,6 @@ class ScanWithCustomFramework(BaseKubescape):
         Logger.logger.info("Stage 3.2: Test custom framework deleted")
         self.test_scan_custom_fw_deleted(fw_name)
 
-        Logger.logger.info("Deleting cluster from backend")
-        self.delete_cluster_from_backend_and_tested()
         return self.cleanup()
 
     def cleanup(self):

--- a/tests_scripts/payments/base_payment.py
+++ b/tests_scripts/payments/base_payment.py
@@ -32,12 +32,11 @@ class BasePayment(base_test.BaseTest):
         return active_subscription
 
     def cancel_test_subscriptions(self):
-        for tenantID in self.test_tenants_ids:
-            response = self.backend.cancel_subscription(tenantID)
-            if response.status_code != client.OK:
-                Logger.logger.error(f"cancel subscription for tenant {tenantID} failed")
-            else:
-                Logger.logger.info(f"canceled subscription for tenant {tenantID}")
+        response = self.backend.cancel_subscription(self.test_tenant_id)
+        if response.status_code != client.OK:
+            Logger.logger.error(f"cancel subscription for tenant {self.test_tenant_id} failed")
+        else:
+            Logger.logger.info(f"canceled subscription for tenant {self.test_tenant_id}")
 
     def cleanup(self, **kwargs):
         return super().cleanup(**kwargs)

--- a/tests_scripts/payments/checkout.py
+++ b/tests_scripts/payments/checkout.py
@@ -17,9 +17,6 @@ class Checkout(BaseStripe):
         super(Checkout, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
 
     def start(self):
-
-        test_tenant_id = self.create_new_tenant()
-
         Logger.logger.info("Stage 1: Go to stripe checkout page for each price")
 
         for price in self.expected_prices:

--- a/tests_scripts/payments/plans.py
+++ b/tests_scripts/payments/plans.py
@@ -12,8 +12,6 @@ class Plans(BaseStripe):
         super(Plans, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
     
     def start(self):
-        Logger.logger.info("Create new tenant")
-        test_tenant_id = self.create_new_tenant()
     
         response = self.backend.get_stripe_plans()
         assert "plans" in response.json(), "'plans' not found in response"

--- a/tests_scripts/payments/portal.py
+++ b/tests_scripts/payments/portal.py
@@ -12,17 +12,15 @@ class Portal(BaseStripe):
 
     def start(self):
         quantity = 5
-        Logger.logger.info("Create new tenant")
-        test_tenant_id = self.create_new_tenant()
 
         Logger.logger.info("Stage 1: create a subscription")
-        response = self.create_subscription(self.expected_prices[0]["name"], self.test_stripe_customer_id, quantity, test_tenant_id)
+        response = self.create_subscription(self.expected_prices[0]["name"], self.test_stripe_customer_id, quantity, self.test_tenant_id)
 
         Logger.logger.info("Stage 2: Get billing portal URL")
         response = self.stripe_billing_portal()
 
         Logger.logger.info("Stage 3: cancel a subscription")
-        response = self.cancel_subscription(test_tenant_id)
+        response = self.cancel_subscription(self.test_tenant_id)
 
         return self.cleanup()
     

--- a/tests_scripts/payments/webhook.py
+++ b/tests_scripts/payments/webhook.py
@@ -19,17 +19,16 @@ class StripeWebhook(BaseStripe):
 
 
     def start(self):
-        test_tenant_id = self.create_new_tenant()
         quantity = 5
 
         Logger.logger.info("Stage 1: create a subscription")
-        response = self.create_subscription(self.expected_prices[0]["name"], self.test_stripe_customer_id, quantity, test_tenant_id)
+        response = self.create_subscription(self.expected_prices[0]["name"], self.test_stripe_customer_id, quantity, self.test_tenant_id)
 
         Logger.logger.info("Stage 2: cancel a subscription")
-        response = self.cancel_subscription(test_tenant_id)
+        response = self.cancel_subscription(self.test_tenant_id)
 
         Logger.logger.info("Stage 3: renew a subscription")
-        response = self.renew_subscription(test_tenant_id)
+        response = self.renew_subscription(self.test_tenant_id)
    
         return self.cleanup()
     


### PR DESCRIPTION

**Expanding test tenant capabilities:**

1. _Enabling test tenant_ - in order to have a test run under a test tenant, need to send to the test configuration `create_test_tenant = True` (default is false).  Tenant name structure - "auto_systest_[timeFloat]"
2. _Deleting a test tenant_ (applied only if ` create_test_tenant = True`) - it is possible to control when to delete the test tenant on test execution by sending the --delete_test_tenant args with one of the following options:
**ALWAYS** (Default) - delete upon test end.
**TEST_PASSED** - delete only if test passed (good for further analysis of failing)
**NEVER** - never delete (good for UI QA).

Note: on jenkins, delete_test_tenant is also supported as an env variable. (if not configured, default value will be applied).

**Cluster deletion when test ends:**

Unified cluster deletion management under `delete_cluster_from_backend` function. This function will be called only from the cleanup function(s) when needed, no need to delete a cluster from the test core flow.
