### PR TITLE
Security framework tests

### DIFF
--- a/configurations/system/tests_cases/kubescape_tests.py
+++ b/configurations/system/tests_cases/kubescape_tests.py
@@ -14,7 +14,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=Scan,
             policy_scope='framework',
-            policy_name='nsa'
+            policy_name='NSA'
         )
 
     @staticmethod
@@ -24,7 +24,17 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=Scan,
             policy_scope='framework',
-            policy_name='mitre'
+            policy_name='MITRE'
+        )
+    
+    @staticmethod
+    def scan_security():
+        from tests_scripts.kubescape.scan import Scan
+        return KubescapeConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=Scan,
+            policy_scope='framework',
+            policy_name='security'
         )
 
     @staticmethod
@@ -34,7 +44,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanWithExceptions,
             policy_scope='framework',
-            policy_name='mitre',
+            policy_name='MITRE',
             exceptions='kube-ns.json',
             controls_tested=["C-0002"]
         )
@@ -58,7 +68,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanUrl,
             policy_scope='framework',
-            policy_name='mitre',
+            policy_name='MITRE',
             url="https://github.com/armosec/kubescape"
         )
 
@@ -88,7 +98,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanGitRepositoryAndSubmit,
             policy_scope='framework',
-            policy_name='mitre',
+            policy_name='MITRE',
             submit=True,
             account=True,
             git_repository=GitRepository(name='examples', owner="kubernetes", branch="master",
@@ -103,7 +113,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanLocalFile,
             policy_scope='framework',
-            policy_name='nsa',
+            policy_name='NSA',
             yamls=['nginx.yaml'],
             resources=1
         )
@@ -115,7 +125,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanLocalFile,
             policy_scope='framework',
-            policy_name='nsa',
+            policy_name='NSA',
             yamls=['hipster_shop/*.yaml'],
             resources=13
         )
@@ -139,12 +149,28 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanAndSubmitToBackend,
             policy_scope='framework',
-            policy_name='nsa',
+            policy_name='NSA',
             submit=True,
             account=True,
             resources_for_test=[
                 {'kind': 'Deployment', 'name': 'apache', 'namespace': 'system-test', 'apiVersion': 'apps/v1'},
                 {'kind': 'Namespace', 'name': 'system-test', 'namespace': '', 'apiVersion': 'v1'}],
+            yaml="apache.yaml",
+            namespace="system-test"
+        )
+    
+    @staticmethod
+    def scan_security_and_submit_to_backend():
+        from tests_scripts.kubescape.scan import ScanAndSubmitToBackend
+        return KubescapeConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=ScanAndSubmitToBackend,
+            policy_scope='framework',
+            policy_name='security',
+            submit=True,
+            account=True,
+            resources_for_test=[
+                {'kind': 'Deployment', 'name': 'apache', 'namespace': 'system-test', 'apiVersion': 'apps/v1'}],
             yaml="apache.yaml",
             namespace="system-test"
         )
@@ -156,7 +182,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanAndSubmitToBackend,
             policy_scope='framework',
-            policy_name='mitre',
+            policy_name='MITRE',
             submit=True,
             account=True,
             resources_for_test=[
@@ -173,7 +199,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanWithExceptionToBackend,
             policy_scope='framework',
-            policy_name='nsa',
+            policy_name='NSA',
             submit=True,
             account=True,
             exceptions="exclude-control-apache.json,exclude-control-sa-resourceID-apache.json",
@@ -214,7 +240,7 @@ class KubescapeTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=OfflineSupport,
             policy_scope='framework',
-            policy_name='nsa',
+            policy_name='NSA',
             yaml=["apache.yaml"],
             namespace="system-test",
             expected_results='apache.json'

--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -34,6 +34,9 @@ LOGIN_METHOD_FRONTEGG_USERNAME = "frontegg_username"
 
 API_FRONTEGG_IDENTITY_RESOURCES_USERS_V2_USERS_V2_ME_TENANTS = "/frontegg/identity/resources/users/v2/me/tenants"
 
+SECURITY_FRAMEWORKS = ["security"]
+SECURITY_FRAMEWORK_TYPETAG = "security"
+
 
 API_STRIPE_BILLING_PORTAL = "/api/v1/tenants/stripe/portal"
 API_STRIPE_CHECKOUT = "/api/v1/tenants/stripe/checkout"
@@ -102,12 +105,12 @@ def deco_cookie(func):
         if "cookies" not in kwargs:
             if "/api/v1/admin/" in url:
                 kwargs["cookies"] = ControlPanelAPIObj.login_customer_cookie
-                if "customerGuid" not in kwargs["params"]:
-                    kwargs["params"]["customerGuid"] = ControlPanelAPIObj.login_customer_guid
+                if "customerGUID" not in kwargs["params"]:
+                    kwargs["params"]["customerGUID"] = ControlPanelAPIObj.login_customer_guid
             else:
                 kwargs["cookies"] = ControlPanelAPIObj.selected_tenant_cookie
-                if "customerGuid" not in kwargs["params"]:
-                    kwargs["params"]["customerGuid"] = ControlPanelAPIObj.selected_tenant_id
+                if "customerGUID" not in kwargs["params"]:
+                    kwargs["params"]["customerGUID"] = ControlPanelAPIObj.selected_tenant_id
 
         kwargs['headers'] = kwargs.get("headers", ControlPanelAPIObj.auth)
         kwargs["timeout"] = kwargs.get("timeout", 21)
@@ -704,7 +707,11 @@ class ControlPanelAPI(object):
     def get_posture_clusters_overtime(self, cluster_name: str, framework_name: str = ""):
         params = {"pageNum": 1, "pageSize": 1, "orderBy": "timestamp:desc", "innerFilters": [{
             "clusterName": cluster_name, "frameworkName": framework_name}]}
-        r = self.post(API_POSTURE_CLUSTERSOVERTIME, params={"customerGUID": self.selected_tenant_id},
+
+        if framework_name in SECURITY_FRAMEWORKS:
+            params["innerFilters"][0]["typeTags"] = SECURITY_FRAMEWORK_TYPETAG
+
+        r = self.post(API_POSTURE_CLUSTERSOVERTIME,
                       json=params)
         if not 200 <= r.status_code < 300:
             raise Exception(
@@ -812,6 +819,10 @@ class ControlPanelAPI(object):
     def get_posture_frameworks(self, report_guid: str, framework_name: str = ""):
         params = {"pageNum": 1, "pageSize": 1000, "orderBy": "timestamp:desc", "innerFilters": [{
             "reportGUID": report_guid, "name": framework_name}]}
+        
+        if framework_name in SECURITY_FRAMEWORKS:
+            params["innerFilters"][0]["typeTags"] = SECURITY_FRAMEWORK_TYPETAG
+
         r = self.post(API_POSTURE_FRAMEWORKS, params={"customerGUID": self.selected_tenant_id},
                       json=params)
         if not 200 <= r.status_code < 300:

--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -34,9 +34,6 @@ LOGIN_METHOD_FRONTEGG_USERNAME = "frontegg_username"
 
 API_FRONTEGG_IDENTITY_RESOURCES_USERS_V2_USERS_V2_ME_TENANTS = "/frontegg/identity/resources/users/v2/me/tenants"
 
-SECURITY_FRAMEWORKS = ["security"]
-SECURITY_FRAMEWORK_TYPETAG = "security"
-
 
 API_STRIPE_BILLING_PORTAL = "/api/v1/tenants/stripe/portal"
 API_STRIPE_CHECKOUT = "/api/v1/tenants/stripe/checkout"
@@ -708,8 +705,8 @@ class ControlPanelAPI(object):
         params = {"pageNum": 1, "pageSize": 1, "orderBy": "timestamp:desc", "innerFilters": [{
             "clusterName": cluster_name, "frameworkName": framework_name}]}
 
-        if framework_name in SECURITY_FRAMEWORKS:
-            params["innerFilters"][0]["typeTags"] = SECURITY_FRAMEWORK_TYPETAG
+        if framework_name in statics.SECURITY_FRAMEWORKS:
+            params["innerFilters"][0]["typeTags"] = statics.SECURITY_FRAMEWORK_TYPETAG
 
         r = self.post(API_POSTURE_CLUSTERSOVERTIME,
                       json=params)
@@ -820,8 +817,8 @@ class ControlPanelAPI(object):
         params = {"pageNum": 1, "pageSize": 1000, "orderBy": "timestamp:desc", "innerFilters": [{
             "reportGUID": report_guid, "name": framework_name}]}
         
-        if framework_name in SECURITY_FRAMEWORKS:
-            params["innerFilters"][0]["typeTags"] = SECURITY_FRAMEWORK_TYPETAG
+        if framework_name in statics.SECURITY_FRAMEWORKS:
+            params["innerFilters"][0]["typeTags"] = statics.SECURITY_FRAMEWORK_TYPETAG
 
         r = self.post(API_POSTURE_FRAMEWORKS, params={"customerGUID": self.selected_tenant_id},
                       json=params)

--- a/jenkins_files/Jenkinsfile-helm-ks-be.groovy
+++ b/jenkins_files/Jenkinsfile-helm-ks-be.groovy
@@ -26,6 +26,7 @@ def tests = [
              "ks_microservice_delete_cronjob":                                            ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "ks_microservice_create_2_cronjob_mitre_and_nsa":                            ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "scan_with_exceptions":                                                      ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
+             "scan_security_and_submit_to_backend":                                       ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "scan_nsa_and_submit_to_backend":                                            ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "scan_mitre_and_submit_to_backend":                                          ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "scan_local_repository_and_submit_to_backend":                               ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],

--- a/jenkins_files/Jenkinsfile_kubescape.groovy
+++ b/jenkins_files/Jenkinsfile_kubescape.groovy
@@ -2,7 +2,9 @@ def backend = "${env.BACKEND}"
 def ks_branch = "${env.KS_BRANCH}"
 
 // Add ONLY kubescape-CLI tests (do NOT add any HELM related tests)
-def tests = ["scan_nsa":                                                                                            ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
+def tests = [
+             "scan_security":                                                                                       ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
+             "scan_nsa":                                                                                            ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "scan_mitre":                                                                                          ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "scan_with_exceptions":                                                                                ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "scan_repository":                                                                                     ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],

--- a/readme.md
+++ b/readme.md
@@ -3,13 +3,15 @@
 ## Test Cases:
 | Test name                                                      |  category  | description                                                            | coverage                      |
 |----------------------------------------------------------------|:----------:|------------------------------------------------------------------------|-------------------------------|
+| `scan_security`                                                | kubescape, security  | simple scan framework security                                              | kubescape                     |
 | `scan_nsa`                                                     | kubescape  | simple scan framework NSA                                              | kubescape                     |
 | `scan_mitre`                                                   | kubescape  | simple scan framework MITRE                                            | kubescape                     |
 | `scan_with_exceptions`                                         | kubescape  | scan framework NSA with exceptions                                     | kubescape                     |
 | `scan_repository`                                              | kubescape  | scan repository                                                        | kubescape                     |
 | `scan_local_file`                                              | kubescape  | scan local file                                                        | kubescape                     |
 | `scan_local_glob_files`                                        | kubescape  | scan local glob files                                                  | kubescape                     |
-| `scan_local_list_of_files`                                     | kubescape  | scan local list of files                                               | kubescape                     |
+| `scan_local_list_of_files`                                     | kubescape  | scan local list of files                                               | kubescape      
+| `scan_security_and_submit_to_backend`                               | kubescape, security  | scan framework NSA and test results against the backend,                | kubescape, backend                 |
 | `scan_nsa_and_submit_to_backend`                               | kubescape  | scan framework NSA and test results against the backend                | kubescape, backend            | 
 | `scan_mitre_and_submit_to_backend`                             | kubescape  | scan framework MITRE and test results against the backend              | kubescape, backend            | 
 | `scan_local_repository_and_submit_to_backend`                  | kubescape  | scan local repository and test results against the backend             | kubescape, backend            | 

--- a/systest_utils/statics.py
+++ b/systest_utils/statics.py
@@ -1,5 +1,10 @@
 import os
 
+
+SECURITY_FRAMEWORKS = ["security"]
+SECURITY_FRAMEWORK_TYPETAG = "security"
+
+
 SUCCESS = True
 FAILURE = False
 

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -727,7 +727,7 @@ class BaseKubescape(BaseK8S):
         report_guid = self.get_report_guid(cluster_name=cluster_name, framework_name=framework_name,
                                            old_report_guid=old_report_guid)
 
-        # "secuirty" framework is excluded from postureClusters report, therefore on this case skippin g testing apui version.
+        # "security" framework is excluded from postureClusters report, therefore on this case skipping testing api version.
         if framework_name not in statics.SECURITY_FRAMEWORKS:
             self.test_api_version_info()
 

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -727,7 +727,9 @@ class BaseKubescape(BaseK8S):
         report_guid = self.get_report_guid(cluster_name=cluster_name, framework_name=framework_name,
                                            old_report_guid=old_report_guid)
 
-        self.test_api_version_info()
+        # "secuirty" framework is excluded from postureClusters report, therefore on this case skippin g testing apui version.
+        if framework_name not in statics.SECURITY_FRAMEWORKS:
+            self.test_api_version_info()
 
         self.compare_top_controls_data(cli_result=cli_result, cluster_name=cluster_name, report_guid=report_guid,
                                        framework_name=framework_name)

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -555,7 +555,7 @@ class BaseKubescape(BaseK8S):
                 # TODO - support list of controls
                 return control['ruleReports'][0]['ruleResponses']
 
-    def test_filed_controls_in_resource(self, cli_result: dict, be_resources: list, cluster: str, kind: str, name: str,
+    def test_failed_controls_in_resource(self, cli_result: dict, be_resources: list, cluster: str, kind: str, name: str,
                                         namespace: str, api_version: str):
         be_affected_controls = BaseKubescape.get_attributes_from_be_resources(be_resources=be_resources, kind=kind,
                                                                               cluster=cluster, name=name,
@@ -679,16 +679,9 @@ class BaseKubescape(BaseK8S):
                                                                                             scored=control['scored'])
 
     def test_resources_from_backend(self, cli_result: dict, be_resources: list):
-        # self.test_filed_controls_in_resource(cli_result=cli_result, be_resources=be_resources, kind='Pod',
-        #                                      cluster=self.kubernetes_obj.get_cluster_name(),
-        #                                      name='kube-controller-manager',
-        #                                      namespace='kube-system')
-        # self.test_filed_controls_in_resource(cli_result=cli_result, be_resources=be_resources, kind='Namespace',
-        #                                      cluster=self.kubernetes_obj.get_cluster_name(),
-        #                                      name='kube-system', namespace='')
         resources_obj = self.test_obj[("resources_for_test", [])]
-        for resource_obj in self.test_obj[("resources_for_test", [])]:
-            self.test_filed_controls_in_resource(cli_result=cli_result, be_resources=be_resources,
+        for resource_obj in resources_obj:
+            self.test_failed_controls_in_resource(cli_result=cli_result, be_resources=be_resources,
                                                  kind=resource_obj['kind'], api_version=resource_obj['apiVersion'],
                                                  cluster=self.kubernetes_obj.get_cluster_name(),
                                                  name=resource_obj['name'], namespace=resource_obj['namespace'])

--- a/tests_scripts/kubescape/scan.py
+++ b/tests_scripts/kubescape/scan.py
@@ -193,7 +193,7 @@ class ScanAndSubmitToBackend(BaseKubescape):
         self.apply_yaml_file(yaml_file=self.test_obj.get_arg("yaml"), namespace=namespace)
 
         old_report_guid = self.get_report_guid(cluster_name=self.kubernetes_obj.get_cluster_name(), wait_to_result=True,
-                                               framework_name=self.test_obj.get_arg("policy_name").upper())
+                                               framework_name=self.test_obj.get_arg("policy_name"))
 
         Logger.logger.info("Scanning kubescape")
         cli_result = self.default_scan(policy_scope=self.test_obj.policy_scope, policy_name=self.test_obj.policy_name,
@@ -203,7 +203,7 @@ class ScanAndSubmitToBackend(BaseKubescape):
 
         Logger.logger.info("Testing data in backend")
         self.test_data_in_be(cli_result=cli_result, cluster_name=self.kubernetes_obj.get_cluster_name(),
-                             framework_name=(self.test_obj.get_arg("policy_name")).upper(),
+                             framework_name=(self.test_obj.get_arg("policy_name")),
                              old_report_guid=old_report_guid)
 
         return self.cleanup()


### PR DESCRIPTION
Added tests:
- scan_security - scan "security" framework without submitting to backend.
- scan_security_and_submit_to_backend - scan "security" framework and submit to backend.

Bugs fixed:
- backend_api.py - fixed duplication of sending "customerGuid" in query string.
- Removed "upper()" for kubescape scan tests, framework is now case-sensitive.