### PR TITLE
use ready state in get_running_pods

### DIFF
--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -32,11 +32,11 @@ class BaseVulnerabilityScanning(BaseHelm):
             for severity in container_scan['severitiesStats']:
                 rce_fix_count += severity['rceFixCount']
             assert rce_fix_count == container_scan['rceFixCount']
-      
+
     @staticmethod
     def count_containers_with_severity(be_summary: dict, severityLvl: str, fixable: bool = False):
         count = 0
-        for container_scan in be_summary:        
+        for container_scan in be_summary:
             for severity in container_scan['severitiesStats']:
                 if fixable and severity['fixedTotal'] < 1:
                     continue
@@ -44,7 +44,7 @@ class BaseVulnerabilityScanning(BaseHelm):
                     continue
                 count += 1
         return count
-        
+
     @staticmethod
     def test_no_errors_in_scan_result(be_summary: dict):
         for scan in be_summary:
@@ -54,13 +54,13 @@ class BaseVulnerabilityScanning(BaseHelm):
                     num=len(scan[statics.SCAN_RESULT_ERRORS_FIELD]),
                     error_lst=scan[statics.SCAN_RESULT_ERRORS_FIELD]
                 )
-            
+
 
     def is_storage_enabled(self):
         if "helm_kwargs" in self.test_obj.kwargs and statics.HELM_STORAGE_FEATURE in self.test_obj.kwargs["helm_kwargs"]:
             return self.test_obj["helm_kwargs"][statics.HELM_STORAGE_FEATURE]
         return False
-    
+
     def test_scan_results_against_expected(self, containers_cve: dict, storage_CVEs = None):
         expected_results = self.create_vulnerabilities_expected_results(
         expected_results=self.test_obj.get_arg('expected_results'))
@@ -74,7 +74,7 @@ class BaseVulnerabilityScanning(BaseHelm):
 
         assert not failed_paths, 'Expect the data from backend would not fail less CVEs then the expected results.\n' \
                                 f'in the following entries is happened:\nfailed_paths: {failed_paths}\n containers_cve: {containers_cve}'
-    
+
     # check that all backend CVEs are in storage
     # check that filtered CVEs have relevantLabel set to 'yes'
     # check that non-filtered CVEs have relevantLabel set to 'no'
@@ -87,7 +87,7 @@ class BaseVulnerabilityScanning(BaseHelm):
             assert container_name in containers_cve.keys(), \
                 f"Expect to receive {container_name} in results_details from backend"
 
-            if len(cve_list) == 0: 
+            if len(cve_list) == 0:
                 continue
 
             image_hash = next(iter(cve_list.items()))[1]['imageHash']
@@ -147,13 +147,13 @@ class BaseVulnerabilityScanning(BaseHelm):
         containers_cve = self.get_container_cve_without_filter_response(since_time=since_time,
                                                                         container_scan_id=containers_scan_id)
 
-        # 5.2 test applied cve exceptions in report 
+        # 5.2 test applied cve exceptions in report
         self.test_applied_cve_exceptions_in_report(containers_cve=containers_cve, cve_exception_guid=cve_exception_guid,
                                                     cves_list=cves_list)
         # 5.3 test ignore rules summary in report
         self.test_cve_ignore_rule_summary_in_report(containers_cve=containers_cve, cve_exception_guid=cve_exception_guid,
                                                     cves_list=cves_list)
-                                                    
+
         return None
 
     @staticmethod
@@ -175,7 +175,7 @@ class BaseVulnerabilityScanning(BaseHelm):
             if not found:
                 result.append(cve)
         assert not result, "test_applied_cve_exceptions failed, not found cvs the applied: {}".format(result)
-        
+
     @staticmethod
     def test_cve_ignore_rule_summary_in_report(containers_cve, cve_exception_guid, cves_list):
         result = []
@@ -243,7 +243,7 @@ class BaseVulnerabilityScanning(BaseHelm):
                 Logger.logger.info('Test backend summary')
                 is_one_relevant = self.is_at_least_one_cve_relevant(containers_cve=containers_cve)
                 self.test_be_summary(be_summary, is_relevant_summary=is_one_relevant, since_time=since_time)
-                
+
                 success = True
                 break
             except Exception as e:
@@ -258,7 +258,7 @@ class BaseVulnerabilityScanning(BaseHelm):
             raise Exception(
                 f"test_cve_result, timeout: {timeout // 60} minutes, error: {err}. ")
 
-        
+
         Logger.logger.info('Test cluster installation data')
         self.test_installation_data()
 
@@ -292,7 +292,7 @@ class BaseVulnerabilityScanning(BaseHelm):
             "imageHash": workload["spec"]["template"]["spec"]["containers"][0]["image"],
         }
         return workload_obj
-    
+
     def get_workload_data_from_deployments(self):
         workload_data = []
         if "deployments" in self.test_obj.kwargs:
@@ -378,7 +378,7 @@ class BaseVulnerabilityScanning(BaseHelm):
             for i in range(len(container_cve)):
                 for j in range(i + 1, len(container_cve)):
                     assert container_cve[i] != container_cve[j], f"got duplicated cve {container_cve[i]} in container {container[_CONTAINER_NAME]}"
-                
+
             name = statics.SCAN_RESULT_NAME_FIELD
             imageHash = statics.SCAN_RESULT_IMAGEHASH_FIELD
             severity = statics.SCAN_RESULT_SEVERITY_FIELD
@@ -395,14 +395,14 @@ class BaseVulnerabilityScanning(BaseHelm):
                     container_cve_dict[item[name]][total_count] += 1
                     container_cve_dict[item[name]][is_relevant] = item[is_relevant]
                     container_cve_dict[item[name]][imageHash] = item[imageHash]
-                    
+
                     if is_rce_cve:
                         container_cve_dict[item[name]][rce_count] += 1
                 else:
                     container_cve_dict[item[name]] = {severity: item[severity], is_rce: item[categories][is_rce],
                 total_count: 1, rce_count: 1 if is_rce_cve else 0, is_relevant: item[is_relevant], imageHash: item[imageHash], is_fixed: item[is_fixed],
                 statics.DESIGNATORS_FIELD: item[statics.DESIGNATORS_FIELD], statics.SCAN_RESULT_IMAGE_TAG_NAME_FIELD: item[statics.SCAN_RESULT_IMAGE_TAG_NAME_FIELD]}
-            
+
             result[container[_CONTAINER_NAME]] = container_cve_dict
 
 
@@ -479,7 +479,7 @@ class BaseVulnerabilityScanning(BaseHelm):
                 containers_severity[name][statics.SCAN_RESULT_RCETOTAL_FIELD] += details[statics.SCAN_RESULT_RCETOTAL_FIELD]
                 containers_severity[name][statics.SCAN_RESULT_TOTAL_FIELD] += details[statics.SCAN_RESULT_TOTAL_FIELD]
                 if details[statics.SCAN_RESULT_IS_FIXED_FIELD] == 1:
-                    containers_severity[name][statics.SCAN_RESULT_FIX_COUNT_FIELD] += details[statics.SCAN_RESULT_TOTAL_FIELD]    
+                    containers_severity[name][statics.SCAN_RESULT_FIX_COUNT_FIELD] += details[statics.SCAN_RESULT_TOTAL_FIELD]
                     if details[statics.SCAN_RESULT_IS_RCE_FIELD] == 1:
                         containers_severity[name][statics.SCAN_RESULT_RCE_FIX_COUNT] += details[statics.SCAN_RESULT_TOTAL_FIELD]
                     if details[statics.SCAN_RESULT_IS_RELEVANT_FIELD] == statics.SCAN_RESULT_IS_RELEVANT_FIELD_TRUE:
@@ -505,7 +505,7 @@ class BaseVulnerabilityScanning(BaseHelm):
                                     x1=statics.SCAN_RESULT_IMAGEHASH_FIELD,
                                         x2=container[statics.SCAN_RESULT_IMAGEHASH_FIELD],
                                         y2=containers_severity[container_severity_key][statics.SCAN_RESULT_IMAGEHASH_FIELD])
-                
+
 
                 assert container[statics.DESIGNATORS_FIELD] == \
                         containers_severity[container_severity_key][statics.DESIGNATORS_FIELD], \
@@ -529,7 +529,7 @@ class BaseVulnerabilityScanning(BaseHelm):
                                x2=container[statics.SCAN_RESULT_RCETOTAL_FIELD],
                                y2=containers_severity[container_severity_key][
                                    statics.SCAN_RESULT_RCETOTAL_FIELD])
-            
+
             assert container[statics.SCAN_RESULT_FIX_COUNT_FIELD] == \
                      containers_severity[container_severity_key][statics.SCAN_RESULT_FIX_COUNT_FIELD], \
                 message.format(x=container[statics.SCAN_RESULT_CONTAINER_NAME_FIELD],
@@ -537,7 +537,7 @@ class BaseVulnerabilityScanning(BaseHelm):
                                     x2=container[statics.SCAN_RESULT_FIX_COUNT_FIELD],
                                     y2=containers_severity[container_severity_key][
                                         statics.SCAN_RESULT_FIX_COUNT_FIELD])
-            
+
             assert container[statics.SCAN_RESULT_RELEVANT_TOTAL_FIELD] == \
                         containers_severity[container_severity_key][statics.SCAN_RESULT_RELEVANT_TOTAL_FIELD], \
                 message.format(x=container[statics.SCAN_RESULT_CONTAINER_NAME_FIELD],
@@ -545,16 +545,16 @@ class BaseVulnerabilityScanning(BaseHelm):
                                     x2=container[statics.SCAN_RESULT_RELEVANT_TOTAL_FIELD],
                                     y2=containers_severity[container_severity_key][
                                         statics.SCAN_RESULT_RELEVANT_TOTAL_FIELD])
-            
+
 
             assert container[statics.SCAN_RESULT_RCE_FIX_COUNT] == \
                         containers_severity[container_severity_key][statics.SCAN_RESULT_RCE_FIX_COUNT], \
                 message.format(x=container[statics.SCAN_RESULT_CONTAINER_NAME_FIELD],
-                                    x1=statics.SCAN_RESULT_RCE_FIX_COUNT,   
+                                    x1=statics.SCAN_RESULT_RCE_FIX_COUNT,
                                     x2=container[statics.SCAN_RESULT_RCE_FIX_COUNT],
                                     y2=containers_severity[container_severity_key][
                                         statics.SCAN_RESULT_RCE_FIX_COUNT])
-            
+
             assert container[statics.SCAN_RESULT_RELEVANT_FIX_COUNT] == \
                         containers_severity[container_severity_key][statics.SCAN_RESULT_RELEVANT_FIX_COUNT], \
                 message.format(x=container[statics.SCAN_RESULT_CONTAINER_NAME_FIELD],
@@ -612,7 +612,7 @@ class BaseVulnerabilityScanning(BaseHelm):
     def get_cluster_info(self, cluster_name: str):
         cluster_info, t = self.wait_for_report(report_type=self.backend.get_cluster, cluster_name=cluster_name)
         return cluster_info
-    
+
     def get_image_scan_stats(self):
         image_scan_stats, t = self.wait_for_report(report_type=self.backend.get_image_scan_stats)
         return image_scan_stats
@@ -836,8 +836,8 @@ class BaseVulnerabilityScanning(BaseHelm):
         """
         check that the workload properties are as expected in backend summary
         """
-        assert workload_obj["kind"].lower() == summary["designators"]['attributes']["kind"].lower(), f"Expect to receive kind {workload_obj['kind'].lower()} but received {summary['designators']['attributes']['kind'].lower()}"                    
-        
+        assert workload_obj["kind"].lower() == summary["designators"]['attributes']["kind"].lower(), f"Expect to receive kind {workload_obj['kind'].lower()} but received {summary['designators']['attributes']['kind'].lower()}"
+
         assert workload_obj["containerName"] == summary['designators']['attributes']['containerName'], f"Expect to receive apiVersion {workload_obj['containerName']} but received {summary['designators']['attributes']['containerName']}"
 
         assert workload_obj["containerName"] == summary["containerName"], f"Expect to receive containerName {workload_obj['containerName']} but received {summary['containerName']}"
@@ -860,19 +860,19 @@ class BaseVulnerabilityScanning(BaseHelm):
                 f"Expect to receive customer guid {customer_guid} but received {summary['designators']['attributes']['customerGUID']}"
             assert summary['designators']['attributes'][statics.CLUSTER_ATTRIBUTE_FIELD] == cluster, \
                 f"Expect to receive cluster name {cluster} but received {summary['designators']['attributes']['clusterName']}"
-            
+
             assert summary[statics.CUSTOMER_GUID_ATTRIBUTE_FIELD] == customer_guid, \
                 f"Expect to receive customer guid {customer_guid} but   received {summary[statics.CUSTOMER_GUID_ATTRIBUTE_FIELD]}"
             assert summary[statics.CLUSTER_ATTRIBUTE_FIELD] == cluster, \
                 f"Expect to receive cluster name {cluster} but received {summary[statics.CLUSTER_ATTRIBUTE_FIELD]}"
-            
+
             assert summary["status"] == "Success", f"Expect to receive status completed, but received {summary['status']}"
 
             for workload_obj in workload_objs:
                 if workload_obj["name"] == summary["designators"]['attributes']["name"]:
                     self.test_workload_properties(summary=summary, workload_obj=workload_obj)
                     break
-                    
+
             # check that each workload is present only once
             workload_identifier = f"{summary['wlid']}/{summary['designators']['attributes']['containerName']}/{summary['registry']}/{summary['imageTag']}"
             assert workload_identifier not in workload_identifiers , f"Expect to receive unique workload identifier, but received {workload_identifier} twice"
@@ -896,7 +896,7 @@ class BaseVulnerabilityScanning(BaseHelm):
             resp = self.backend.get_unique_values_for_field_scan_summary(since_time=since_time, field=field, customer_guid=customer_guid)
             resp = resp.json()
             resp_for_field = resp['fields'][field]
-            for value in resp_for_field: 
+            for value in resp_for_field:
                 if value == '':
                     continue
                 # first value is always empty (for all values)
@@ -918,20 +918,20 @@ class BaseVulnerabilityScanning(BaseHelm):
                                                  cluster_name=self.kubernetes_obj.get_cluster_name(), timeout=600)
         assert cluster_result, 'Failed to verify deleting cluster {x} from backend'. \
             format(x=self.kubernetes_obj.get_cluster_name())
-    
+
     def get_files_from_SBOM(self, SBOM):
         files = []
         if SBOM['spec']['spdx']['files'] is not None:
             for fileData in SBOM['spec']['spdx']['files']:
                 files.append(fileData['fileName'])
         return files
-    
+
     def get_annotations_from_SBOM(self, SBOM):
         annotations = {}
         for key, annotation in SBOM['metadata']['annotations'].items():
             annotations[key] = annotation
         return annotations
-    
+
     def validate_expected_SBOM(self, SBOMs, expected_SBOM_paths):
         verified_SBOMs = 0
         for expected_SBOM in expected_SBOM_paths:
@@ -945,10 +945,10 @@ class BaseVulnerabilityScanning(BaseHelm):
                     expected_SBOM_annotations = self.get_annotations_from_SBOM(expected_SBOM_data)
                     for key, annotation in expected_SBOM_annotations.items():
                         assert SBOM_annotations[key] == annotation, f"annotation {key}:{annotation} != {SBOM_annotations[key]} in the SBOM in the storage is not as expected"
-                    
+
                     expected_SBOM_file_list = self.get_files_from_SBOM(expected_SBOM_data)
                     SBOM_file_list = self.get_files_from_SBOM(SBOM[1])
-                    assert expected_SBOM_file_list == SBOM_file_list, "the files in the SBOM in the storage is not as expected" 
+                    assert expected_SBOM_file_list == SBOM_file_list, "the files in the SBOM in the storage is not as expected"
                     verified_SBOMs += 1
                     break
         assert verified_SBOMs == len(expected_SBOM_paths), "not all SBOMs were verified"
@@ -962,7 +962,7 @@ class BaseVulnerabilityScanning(BaseHelm):
                 vuln = match['vulnerability']
                 cves.append(vuln['id'])
         return cves
-    
+
     def store_filter_data_for_first_time_results(self, result, store_path, namespace):
         with open(store_path, 'r') as content_file:
             content = content_file.read()
@@ -975,7 +975,7 @@ class BaseVulnerabilityScanning(BaseHelm):
             del result_data['metadata']['labels'][statics.RELEVANCY_NAMESPACE_LABEL]
             with open(store_path, 'w') as f:
                 json.dump(result_data, f)
-    
+
     def validate_expected_filtered_SBOMs(self, SBOMs, expected_SBOM_paths,namespace):
         verified_SBOMs = 0
         for expected_SBOM in expected_SBOM_paths:
@@ -992,15 +992,15 @@ class BaseVulnerabilityScanning(BaseHelm):
                     expected_SBOM_annotations = self.get_annotations_from_SBOM(expected_SBOM_data)
                     for key, annotation in expected_SBOM_annotations.items():
                         assert SBOM_annotations[key] == annotation, f"annotation {key}:{annotation} in the SBOM in the storage is not as expected"
-                    
+
                     expected_SBOM_file_list = self.get_files_from_SBOM(expected_SBOM_data)
                     SBOM_file_list = self.get_files_from_SBOM(SBOM[1])
-                    assert expected_SBOM_file_list == SBOM_file_list, f"the files in the SBOM in the storage is not as expected, expected: {expected_SBOM_file_list}\n storage: {SBOM_file_list}" 
+                    assert expected_SBOM_file_list == SBOM_file_list, f"the files in the SBOM in the storage is not as expected, expected: {expected_SBOM_file_list}\n storage: {SBOM_file_list}"
                     verified_SBOMs += 1
                     break
         assert verified_SBOMs == len(expected_SBOM_paths), "not all SBOMs were verified"
 
-    
+
     def validate_expected_filtered_CVEs(self, CVEs, expected_CVEs_path,namespace):
         verified_CVEs = 0
         for expected_CVE in expected_CVEs_path:
@@ -1040,12 +1040,12 @@ class BaseVulnerabilityScanning(BaseHelm):
     def get_kind_from_instance_id(instance_id: str):
         result = re.search('kind-(.*)/name', instance_id)
         return result.group(1)
-    
+
     @staticmethod
     def get_name_from_instance_id(instance_id: str):
         result = re.search('name-(.*)/containerName', instance_id)
         return result.group(1)
-    
+
     @staticmethod
     def sanitize_instance_id(instance_id):
         if len(instance_id) > 243:
@@ -1067,7 +1067,7 @@ class BaseVulnerabilityScanning(BaseHelm):
         if isinstance(workload_objs, list):
             instance_IDS: list = [self.get_wlid(workload=i, **kwargs) for i in workload_objs]
             return instance_IDS[0] if len(instance_IDS) == 1 else instance_IDS
-    
+
     def get_workload_image_hash(self, container, **kwargs):
         image_hash_parts=container['image'].split("@sha256:")
         if len(image_hash_parts) != 2:
@@ -1121,7 +1121,7 @@ class BaseVulnerabilityScanning(BaseHelm):
                     cve_list.append(cve["vulnerability"]["id"])
                 break
         return cve_list
-    
+
     def is_relevancy_enabled(self):
         if "helm_kwargs" in self.test_obj.kwargs and statics.HELM_RELEVANCY_FEATURE in self.test_obj.kwargs["helm_kwargs"]:
                 return self.test_obj["helm_kwargs"][statics.HELM_RELEVANCY_FEATURE] == statics.HELM_RELEVANCY_FEATURE_ENABLED
@@ -1142,13 +1142,13 @@ class BaseVulnerabilityScanning(BaseHelm):
                 for image_ids in image_workload_ids:
                     for image_id in image_ids:
                         if image_tag[container_name_index] == image_id[container_name_index]:
-                            SBOM_keys.append(BaseVulnerabilityScanning.parse_container_key(image_tag[container_image_tag_index], image_id[container_image_id_index])) 
+                            SBOM_keys.append(BaseVulnerabilityScanning.parse_container_key(image_tag[container_image_tag_index], image_id[container_image_id_index]))
                             found = True
                             break
                     if found:
                         break
         return SBOM_keys
-    
+
     @staticmethod
     def sanitize_image_tag(image_tag):
         sanitized_image_tag = image_tag
@@ -1156,16 +1156,16 @@ class BaseVulnerabilityScanning(BaseHelm):
         for rep in replace_and_subs:
             sanitized_image_tag = re.sub(rep[0], rep[1], sanitized_image_tag)
         return sanitized_image_tag
-    
+
     def get_workloads_images_tags(self, workload_objs, namespace):
         images_container_tags: list = [self.get_pod_data(get_data_of_pod_call_back=BaseK8S.get_image_tags, namespace=namespace, subname=i["metadata"]["name"]) for i in workload_objs]
         return images_container_tags
-    
+
 
     def get_workloads_images_ids(self, workload_objs, namespace):
         images_container_ids: list = [self.get_pod_data(get_data_of_pod_call_back=BaseK8S.get_image_ids, namespace=namespace, subname=i["metadata"]["name"]) for i in workload_objs]
         return images_container_ids
-    
+
     @staticmethod
     def parse_container_key(image_tag: str, image_id: str):
         image_id_slug_hash_length = 6
@@ -1175,7 +1175,7 @@ class BaseVulnerabilityScanning(BaseHelm):
         slug = slug.lower()
         assert re.match("^[a-z0-9][a-z0-9.-]{0,251}[a-z0-9]$", slug), 'parse_container_key - not valid SBOM key/slug %s'.format(slug)
         return slug
-    
+
 
     def get_filtered_data_keys(self, pods, namespace, **kwargs):
         instance_ids = self.get_instance_IDs(pods=pods, namespace=namespace, kwargs=kwargs)
@@ -1183,8 +1183,8 @@ class BaseVulnerabilityScanning(BaseHelm):
         return filtered_data_keys
 
     def expose_operator(self, cluster):
-        running_pods = self.get_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
-                                             name=statics.CA_OPERATOR_DEPLOYMENT_FROM_HELM_NAME)
+        running_pods = self.get_ready_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
+                                           name=statics.CA_OPERATOR_DEPLOYMENT_FROM_HELM_NAME)
         try:
             self.port_forward_proc = self.kubernetes_obj.portforward(cluster, statics.CA_NAMESPACE_FROM_HELM_NAME,
                                                                      running_pods[0].metadata.name,
@@ -1200,7 +1200,7 @@ class BaseVulnerabilityScanning(BaseHelm):
         data = {
             "commands": [
                 {
-                    "CommandName": "scan",    
+                    "CommandName": "scan",
                     "WildWlid": "wlid://cluster-" + cluster + "/namespace-" + namespace
                 }
             ]

--- a/tests_scripts/helm/vulnerability_scanning.py
+++ b/tests_scripts/helm/vulnerability_scanning.py
@@ -62,7 +62,7 @@ class VulnerabilityScanningProxy(BaseVulnerabilityScanning):
         Logger.logger.info('3.1 verify helm installation')
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME)
 
-   
+
         Logger.logger.info('4. Get the scan result from Backend')
         # In order to check proxy it is enough to check that at least one pod is updated on backend.
         expected_number_of_pods = 1
@@ -76,7 +76,7 @@ class VulnerabilityScanningProxy(BaseVulnerabilityScanning):
         self.uninstall_armo_helm_chart()
 
         return self.cleanup()
-    
+
 
 class VulnerabilityScanning(BaseVulnerabilityScanning):
     def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
@@ -135,14 +135,14 @@ class VulnerabilityScanning(BaseVulnerabilityScanning):
 
 
         Logger.logger.info('Get scan result csv')
-        self.backend.get_scan_results_sum_summary_CSV(namespace=namespace,            
+        self.backend.get_scan_results_sum_summary_CSV(namespace=namespace,
                                                     expected_results=expected_number_of_pods)
         # check CSV with fixable and critical severity filters
-        self.backend.get_scan_results_sum_summary_CSV(namespace=namespace,            
+        self.backend.get_scan_results_sum_summary_CSV(namespace=namespace,
                                                     expected_results=self.count_containers_with_severity(be_summary, "Critical", True),
                                                     severity="Critical", fixable=True)
-            
-            
+
+
 
         # P5 get CVEs results
         # 5.1 get container scan id
@@ -349,8 +349,8 @@ class VulnerabilityScanningRegistry(BaseVulnerabilityScanning):
             Logger.logger.info('verify registry configmap')
 
             cm_applied = f'scanRegistries:registry({registry}) loaded configmap  successful'
-            running_pods = self.get_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
-                                                 name=statics.CA_OPERATOR_DEPLOYMENT_FROM_HELM_NAME)
+            running_pods = self.get_ready_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
+                                               name=statics.CA_OPERATOR_DEPLOYMENT_FROM_HELM_NAME)
             self.wait_for_report(timeout=1200, report_type=self.find_string_in_log,
                                  namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
                                  pod_name=running_pods[0].metadata.name,
@@ -365,8 +365,8 @@ class VulnerabilityScanningRegistry(BaseVulnerabilityScanning):
         if not self.is_image_excluded(img_no_tag[0]):
             Logger.logger.info('verify image in registry was sent to event receiver')
 
-            running_pods = self.get_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
-                                                 name=statics.CA_VULN_SCAN_DEPLOYMENT_FROM_HELM_NAME)
+            running_pods = self.get_ready_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
+                                               name=statics.CA_VULN_SCAN_DEPLOYMENT_FROM_HELM_NAME)
             successful_vuln_scan_log = f'posting to event receiver image {registry}/{self.expected_payloads["image"]} wlid  finished successfully response body:'
             self.wait_for_report(timeout=1200, report_type=self.find_string_in_log,
                                  namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
@@ -381,8 +381,8 @@ class VulnerabilityScanningRegistry(BaseVulnerabilityScanning):
             Logger.logger.info('verify image in registry was excluded properly')
 
             cm_exclude = f"image registry scan::{registry}/{img_no_tag[0]} was excluded"
-            running_pods = self.get_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
-                                                 name=statics.CA_OPERATOR_DEPLOYMENT_FROM_HELM_NAME)
+            running_pods = self.get_ready_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
+                                               name=statics.CA_OPERATOR_DEPLOYMENT_FROM_HELM_NAME)
             self.wait_for_report(timeout=1200, report_type=self.find_string_in_log,
                                  namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
                                  pod_name=running_pods[0].metadata.name,
@@ -470,8 +470,8 @@ class VulnerabilityScanningRegistry(BaseVulnerabilityScanning):
                                                                           body=secret)
 
     def expose_websocket(self, cluster):
-        running_pods = self.get_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
-                                             name=statics.CA_OPERATOR_DEPLOYMENT_FROM_HELM_NAME)
+        running_pods = self.get_ready_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME,
+                                           name=statics.CA_OPERATOR_DEPLOYMENT_FROM_HELM_NAME)
         try:
             self.port_forward_proc = self.kubernetes_obj.portforward(cluster, statics.CA_NAMESPACE_FROM_HELM_NAME,
                                                                      running_pods[0].metadata.name,
@@ -602,7 +602,7 @@ class VulnerabilityScanningRegistryBackendTrigger(VulnerabilityScanningRegistry)
         self.test_registry_cve_result(since_time=since_time, containers_scan_id=containers_scan_id,
                                       be_summary=be_summary)
         Logger.logger.info('Test layers filter')
-        
+
         layers=self.backend.get_registry_container_layers(scan_id)
 
         assert layers == self.expected_layers, \
@@ -620,10 +620,10 @@ class VulnerabilityScanningRegistryBackendTrigger(VulnerabilityScanningRegistry)
 
         assert len(be_summary) == 0, \
                 'Deleted registry returned in summery: {}'.format(be_summary)
-                
+
         registries = self.backend.get_registry_container_cve(since_time=since_time,
                                                                  containers_scan_id=scan_id, total_cve=0)
-        
+
         assert len(registries) == 0, \
                 'Deleted registry returned in details: {}'.format(registries)
 
@@ -650,7 +650,7 @@ class VulnerabilityScanningRegistryBackendTrigger(VulnerabilityScanningRegistry)
 
             Logger.logger.info('sending test registry connectivity request')
             resp = self.backend.test_registry_connectivity_request(cluster_name=cluster_name, registry_name=registry, auth_method=auth_method, excluded_repositories=self.get_excluded_repositories())
-            
+
             Logger.logger.info('testing registry connectivity response')
             self.check_test_registry_connectivity_response(resp=resp, cluster_name=cluster_name, registry_name=registry)
 
@@ -670,7 +670,7 @@ class VulnerabilityScanningRegistryBackendTrigger(VulnerabilityScanningRegistry)
 
                 Logger.logger.info('testing repositories list response')
                 self.check_repositories_list_response(resp=resp, job_id=job_id)
-                
+
 
     def is_passed_statuses(self, expected_statuses):
         for status in expected_statuses:
@@ -685,7 +685,7 @@ class VulnerabilityScanningRegistryBackendTrigger(VulnerabilityScanningRegistry)
         for status in expected_statuses:
             assert resp["data"][status]['status'] == expected_statuses[status], \
                 'job status is wrong: expected {} but got:{}'.format(expected_statuses[status], resp["data"][status]['status'])
-        
+
 
     def check_repositories_list_response(self, resp, job_id):
         assert resp['jobID'] == job_id, \
@@ -709,13 +709,13 @@ class VulnerabilityScanningRegistryBackendTrigger(VulnerabilityScanningRegistry)
     def check_test_registry_connectivity_response(self, resp, cluster_name, registry_name):
         assert resp['action'] == statics.TEST_REGISTRY_CONNECTIVITY_COMMAND, \
                 'action is not testRegistryConnectivity: {}'.format(resp['action'])
-        
+
         assert resp['clusterName'] == cluster_name, \
                 'cluster name is not {}: {}'.format(cluster_name, resp['clusterName'])
 
         assert resp['registryName'] == registry_name, \
                 'registry name is not {}: {}'.format(registry_name, resp['registryName'])
-        
+
         assert resp['jobID'] != '', \
                 'jobID is empty: {}'.format(resp['jobID'])
 
@@ -824,7 +824,7 @@ class VulnerabilityScanningTestRegistryConnectivity(VulnerabilityScanningRegistr
         super(VulnerabilityScanningTestRegistryConnectivity, self).__init__(test_driver=test_driver, test_obj=test_obj,
                                                                           backend=backend,
                                                                           kubernetes_obj=kubernetes_obj)
-        
+
 
 
     def start(self):
@@ -835,18 +835,18 @@ class VulnerabilityScanningTestRegistryConnectivity(VulnerabilityScanningRegistr
 
         Logger.logger.info('Test check_public_quay_registry')
         self.check_public_quay_registry()
-        
+
         if not self.is_excluded_repositories():
             Logger.logger.info('Test check_wrong_registry_name')
             self.check_wrong_registry_name()
-            
+
             Logger.logger.info('Test check_wrong_auth')
             self.check_wrong_auth()
-     
+
         return self.cleanup()
 
 
-    
+
 
     def check_public_quay_registry(self):
         # check that we can connect to public quay.io, all statuses are passed, and excluded repositories are not in response
@@ -870,11 +870,9 @@ class VulnerabilityScanningTestRegistryConnectivity(VulnerabilityScanningRegistr
         auth_method["type"] = "private"
         auth_method["username"] = "accesstoken"
         auth_method["password"] = "invalid"
-   
+
         expected_statuses = {
             statics.TEST_REGISTRY_CONNECTIVITY_AUTHENTICATION_STATUS: statics.TEST_REGISTRY_CONNECTIVITY_FAILED_STATUS,
             statics.TEST_REGISTRY_CONNECTIVITY_INFORMATION_STATUS: statics.TEST_REGISTRY_CONNECTIVITY_PASSED_STATUS,
         }
         self.check_connectivity_for_single_registry(registry=registry, expected_statuses=expected_statuses, auth_method=auth_method)
-
-    

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -11,7 +11,7 @@ try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
-# 
+#
 from datetime import datetime
 from threading import Thread
 
@@ -199,7 +199,7 @@ class BaseK8S(BaseDockerizeTest):
         if self.cluster_deleted:
             Logger.logger.info("Cluster '{}' was confirmed as already deleted from backend".format(cluster_name))
             return True
-        
+
         try:
             cluster_name = self.kubernetes_obj.get_cluster_name()
             try:
@@ -223,9 +223,9 @@ class BaseK8S(BaseDockerizeTest):
                                                     expected_status_code=404)
             assert cluster_result, 'Failed to verify deleting cluster {x} from backend'. \
                 format(x=self.kubernetes_obj.get_cluster_name())
-            
+
             Logger.logger.info("Cluster was deleted successfully '{}'".format(self.kubernetes_obj.get_cluster_name()))
-        
+
             self.cluster_deleted = True
         return True
 
@@ -471,13 +471,13 @@ class BaseK8S(BaseDockerizeTest):
         if wlid:
             namespace = Wlid.get_namespace(wlid=wlid)
             subname = Wlid.get_name(wlid=wlid)
-        names = [pod.metadata.name for pod in self.get_running_pods(namespace=namespace, name=subname)]
+        names = [pod.metadata.name for pod in self.get_ready_pods(namespace=namespace, name=subname)]
         return names[0] if len(names) == 1 else names
-    
+
     @staticmethod
     def get_image_ids(pod):
         return [(container_status.name, container_status.image_id)  for container_status in pod.status.container_statuses]
-    
+
     @staticmethod
     def get_image_tags(pod):
         return [(container_spec.name, container_spec.image)  for container_spec in pod.spec.containers]
@@ -492,7 +492,7 @@ class BaseK8S(BaseDockerizeTest):
         if wlid:
             namespace = Wlid.get_namespace(wlid=wlid)
             subname = Wlid.get_name(wlid=wlid)
-        image_ids = [get_data_of_pod_call_back(pod) for pod in self.get_running_pods(namespace=namespace, name=subname)]
+        image_ids = [get_data_of_pod_call_back(pod) for pod in self.get_ready_pods(namespace=namespace, name=subname)]
         return image_ids[0] if len(image_ids) == 1 else image_ids
 
     @staticmethod
@@ -525,17 +525,17 @@ class BaseK8S(BaseDockerizeTest):
         if len(pod.metadata.owner_references) == 0:
             return self.get_workload(api_version=pod.api_version ,name=pod.metadata.name, kind=pod.kind, namespace=namespace)
         return self.get_workload(api_version=pod.metadata.owner_references[0].api_version ,name=pod.metadata.owner_references[0].name, kind=pod.metadata.owner_references[0].kind, namespace=namespace)
-        
+
     def get_api_version_from_instance_ID(self, instance_ID: str):
         return instance_ID.split("/")[0].split("-")[1]
-    
+
     def get_namespace_from_instance_ID(self, instance_ID: str):
         namespace_list = instance_ID.split("-")
         return "-".join(namespace_list[:3])
-    
+
     def get_kind_from_instance_ID(self, instance_ID: str):
         data = instance_ID.split("-")
-        return "-".join(data[3:4]) 
+        return "-".join(data[3:4])
 
     def get_workload_name_from_instance_ID(self, instance_ID: str):
         data = instance_ID.split("-")
@@ -549,8 +549,8 @@ class BaseK8S(BaseDockerizeTest):
         for container in p_workload['spec']['template']['spec']['containers']:
             instanceIDs.append("apiVersion-" + p_workload["apiVersion"] + "/namespace-" + namespace + "/kind-" + p_workload['kind'] + "/name-" + p_workload['metadata']['name'] + "/containerName-" + container["name"])
         return instanceIDs
-    
-       
+
+
     @staticmethod
     def calculate_sid(secret, **kwargs):
         sid = SID(name=secret['metadata']['name'], **kwargs)
@@ -645,11 +645,11 @@ class BaseK8S(BaseDockerizeTest):
                     replicas += i.spec.replicas
         return replicas
 
-    def get_running_pods(self, namespace, name: str = None):
+    def get_ready_pods(self, namespace, name: str = None):
         """
-        :return: list of running pods with status true
+        :return: list of running pods with all containers ready
         """
-        return list(filter(lambda x: x.status.phase == "Running", self.get_pods(namespace=namespace, name=name)))
+        return list(filter(lambda pod: not any(container.ready is False for container in pod.status.container_statuses or []), self.get_pods(namespace=namespace, name=name)))
 
     def restart_pods(self, wlid=None, namespace: str = None, name: str = None):
         """
@@ -662,7 +662,7 @@ class BaseK8S(BaseDockerizeTest):
             name = Wlid.get_name(wlid=wlid)
             namespace = Wlid.get_namespace(wlid=wlid)
 
-        for j in self.get_running_pods(namespace=namespace):
+        for j in self.get_ready_pods(namespace=namespace):
             if name in j.metadata.name:
                 self.kubernetes_obj.delete_pod(namespace=namespace, name=j.metadata.name)
 
@@ -709,7 +709,7 @@ class BaseK8S(BaseDockerizeTest):
         running_pods = {}
         total_pods = {}
         while delta_t <= timeout:
-            running_pods = self.get_running_pods(namespace=namespace, name=name)
+            running_pods = self.get_ready_pods(namespace=namespace, name=name)
             # total_pods = self.get_pods(namespace=namespace, name=name, include_terminating=False)
             if comp_operator(len(running_pods), replicas):  # and len(running_pods) == len(total_pods):
                 Logger.logger.info(f"all pods are running after {timeout - delta_t} seconds")
@@ -814,7 +814,7 @@ class BaseK8S(BaseDockerizeTest):
     def get_running_containers(self, namespace: str):
         if self.docker.docker_client is None:
             return []
-        pods = self.get_running_pods(namespace=namespace)
+        pods = self.get_ready_pods(namespace=namespace)
         containers = [i for i in self.docker.docker_client.containers.list()]
         return [j for i in pods for j in containers if i.metadata.name in j.name and "_POD_" not in j.name]
 
@@ -824,7 +824,7 @@ class BaseK8S(BaseDockerizeTest):
     #     self.kubernetes_obj.port
 
     def get_pod_ip(self, wlid: str):
-        ips = [pod.status.pod_ip for pod in self.get_running_pods(namespace=Wlid.get_namespace(wlid=wlid)) if
+        ips = [pod.status.pod_ip for pod in self.get_ready_pods(namespace=Wlid.get_namespace(wlid=wlid)) if
                Wlid.get_name(wlid=wlid) in pod.metadata.name]
         return ips[0] if len(ips) > 0 else ""
 
@@ -836,7 +836,7 @@ class BaseK8S(BaseDockerizeTest):
         return tmp_service[0].spec.cluster_ip
 
     def get_image_tag(self, wlid: str):
-        containers = [container for pod in self.get_running_pods(namespace=Wlid.get_namespace(wlid=wlid)) for container
+        containers = [container for pod in self.get_ready_pods(namespace=Wlid.get_namespace(wlid=wlid)) for container
                       in pod.spec.containers if Wlid.get_name(wlid=wlid) in pod.metadata.name]
         image_tags = [container.image.split(':')[-1] for container in containers]
         return image_tags[0]
@@ -972,7 +972,7 @@ class BaseK8S(BaseDockerizeTest):
                 Logger.logger.warning(e)
                 time.sleep(1)
         Logger.logger.info("exiting websocket thread")
-    
+
     def get_SBOM_from_storage(self, SBOMKeys):
         SBOMs = []
         if isinstance(SBOMKeys, str):


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR refactors the `get_running_pods` method in `base_k8s.py` to consider the readiness of the containers within the pods. Previously, the method returned a list of pods in the "Running" phase. Now, it returns a list of pods where at least one container is in the ready state. This change provides a more accurate representation of running pods. Additionally, the PR includes minor formatting changes in the same file.

___
## PR Main Files Walkthrough:
`tests_scripts/kubernetes/base_k8s.py`: The `get_running_pods` method has been updated to return pods where at least one container is in the ready state. Previously, it returned pods in the "Running" phase. This change provides a more accurate representation of running pods. Several lines have been reformatted for better readability.
