### PR TITLE
Support new helm chart and Kubescape version

### DIFF
--- a/configurations/system/backends.py
+++ b/configurations/system/backends.py
@@ -4,7 +4,10 @@ from infrastructure.backend_api import *
 
 class Backend(object):
 
-    def __init__(self, name: str, dashboard: str, 
+    def __init__(self, 
+                 name: str, 
+                 dashboard: str, 
+                 api_url: str,
                  auth_url: str = None, 
                  tls_verify: bool = True, 
                  login_method = LOGIN_METHOD_KEYCLOAK, customer_guid: str = None):
@@ -14,6 +17,7 @@ class Backend(object):
         self.tls_verify = tls_verify
         self.login_method = login_method
         self.customer_guid = customer_guid
+        self.api_url = api_url
 
     def get_dashboard_url(self):
         return self.dashboard
@@ -33,6 +37,9 @@ class Backend(object):
     def get_customer_guid(self):
         return self.customer_guid
 
+    def get_api_url(self):
+        return self.api_url
+
 
 def set_backends():
     backends = list()
@@ -41,6 +48,7 @@ def set_backends():
     # development frontEgg
     backends.append(Backend(name='development',
                             dashboard='https://eggdashbe-dev.armosec.io',
+                            api_url="api-dev.armosec.io",
                             auth_url='https://eggauth-dev.armosec.io',
                             tls_verify=False,
                             login_method=LOGIN_METHOD_FRONTEGG_SECRET))
@@ -49,12 +57,14 @@ def set_backends():
     # staging frontEgg
     backends.append(Backend(name='staging',
                             dashboard='https://eggdashbe-stage.armosec.io',
+                            api_url="api-stage.armosec.io",
                             auth_url='https://eggauth-stage.armosec.io',
                             tls_verify=False,
                             login_method=LOGIN_METHOD_FRONTEGG_SECRET))
 
     # staging frontEgg
     backends.append(Backend(name='production',
+                            api_url="api.armosec.io",
                             dashboard='https://api.armosec.io',
                             auth_url='https://auth.armosec.io',
                             tls_verify=False,
@@ -96,6 +106,7 @@ def set_backends():
 
 
     backends.append(Backend(name='local',
+                            api_url="localhost:7666",
                             dashboard='http://localhost:7666',
                             auth_url='https://eggauth-dev.armosec.io',
                             tls_verify=False,

--- a/infrastructure/api_login.py
+++ b/infrastructure/api_login.py
@@ -69,6 +69,8 @@ class FrontEggSecretAPILogin(APILogin):
     
     def login(self):
         auth = self.getToken()        
+        print(f"Bearer: {auth}")
+        print(f'{self.base_url}{API_OPENID_CUSTOMERS}')
         response =  self.session.get(f'{self.base_url}{API_OPENID_CUSTOMERS}',headers= {'Authorization': f'Bearer: {auth}'})
         assert response.status_code == 200, f"got error: {response.text}, status: {response.status_code}"
         json_res = response.json()

--- a/infrastructure/api_login.py
+++ b/infrastructure/api_login.py
@@ -69,8 +69,6 @@ class FrontEggSecretAPILogin(APILogin):
     
     def login(self):
         auth = self.getToken()        
-        print(f"Bearer: {auth}")
-        print(f'{self.base_url}{API_OPENID_CUSTOMERS}')
         response =  self.session.get(f'{self.base_url}{API_OPENID_CUSTOMERS}',headers= {'Authorization': f'Bearer: {auth}'})
         assert response.status_code == 200, f"got error: {response.text}, status: {response.status_code}"
         json_res = response.json()

--- a/infrastructure/helm_wrapper.py
+++ b/infrastructure/helm_wrapper.py
@@ -29,7 +29,9 @@ class HelmWrapper(object):
     def install_armo_helm_chart(customer: str, server: str, cluster_name: str,
                                 repo: str=statics.HELM_REPO, helm_kwargs:dict={}):
         command_args = ["helm", "upgrade", "--debug", "--install", "kubescape", repo, "-n", statics.CA_NAMESPACE_FROM_HELM_NAME,
-                        "--create-namespace", "--set", "account={x}".format(x=customer),
+                        "--create-namespace",
+                        "--set", "account={x}".format(x=customer),
+                        "--set", "server={x}".format(x=server),
                         "--set", "clusterName={}".format(cluster_name), "--set", "logger.level=debug"]
 
         # by default use offline vuln DB
@@ -41,7 +43,6 @@ class HelmWrapper(object):
         for k, v in helm_kwargs.items():
             command_args.extend(["--set", f"{k}={v}"])
 
-        command_args.extend(["--set", f"server={server}"])
         return_code, return_obj = TestUtil.run_command(command_args=command_args, timeout=360)
         assert return_code == 0, "return_code is {}\nreturn_obj\n stdout: {}\n stderror: {}".format(return_code, return_obj.stdout, return_obj.stderr)
 

--- a/infrastructure/helm_wrapper.py
+++ b/infrastructure/helm_wrapper.py
@@ -42,8 +42,7 @@ class HelmWrapper(object):
 
         for k, v in helm_kwargs.items():
             command_args.extend(["--set", f"{k}={v}"])
-        code, ob = TestUtil.run_command(command_args=["helm", "version"])
-        print("return_code is {}\nreturn_obj\n stdout: {}\n stderror: {}".format(code, ob.stdout, ob.stderr))
+
         return_code, return_obj = TestUtil.run_command(command_args=command_args, timeout=360)
         assert return_code == 0, "return_code is {}\nreturn_obj\n stdout: {}\n stderror: {}".format(return_code, return_obj.stdout, return_obj.stderr)
 

--- a/infrastructure/helm_wrapper.py
+++ b/infrastructure/helm_wrapper.py
@@ -26,7 +26,7 @@ class HelmWrapper(object):
         # os.system("helm repo update armo")
 
     @staticmethod
-    def install_armo_helm_chart(customer: str, environment: str, cluster_name: str,
+    def install_armo_helm_chart(customer: str, server: str, cluster_name: str,
                                 repo: str=statics.HELM_REPO, helm_kwargs:dict={}):
         command_args = ["helm", "upgrade", "--debug", "--install", "kubescape", repo, "-n", statics.CA_NAMESPACE_FROM_HELM_NAME,
                         "--create-namespace", "--set", "account={x}".format(x=customer),
@@ -41,11 +41,7 @@ class HelmWrapper(object):
         for k, v in helm_kwargs.items():
             command_args.extend(["--set", f"{k}={v}"])
 
-
-        if environment in ["development", "dev", "development-egg", "dev-egg"]:
-            command_args.extend(["--set", "environment=dev"])
-        elif environment in ["staging", "stage", "staging-egg", "stage-egg"]:
-            command_args.extend(["--set", "environment=staging"])
+        command_args.extend(["--set", f"server={server}"])
         return_code, return_obj = TestUtil.run_command(command_args=command_args, timeout=360)
         assert return_code == 0, "return_code is {}\nreturn_obj\n stdout: {}\n stderror: {}".format(return_code, return_obj.stdout, return_obj.stderr)
 

--- a/infrastructure/helm_wrapper.py
+++ b/infrastructure/helm_wrapper.py
@@ -42,7 +42,8 @@ class HelmWrapper(object):
 
         for k, v in helm_kwargs.items():
             command_args.extend(["--set", f"{k}={v}"])
-
+        code, ob = TestUtil.run_command(command_args=["helm", "version"])
+        print("return_code is {}\nreturn_obj\n stdout: {}\n stderror: {}".format(code, ob.stdout, ob.stderr))
         return_code, return_obj = TestUtil.run_command(command_args=command_args, timeout=360)
         assert return_code == 0, "return_code is {}\nreturn_obj\n stdout: {}\n stderror: {}".format(return_code, return_obj.stdout, return_obj.stderr)
 

--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -116,7 +116,7 @@ class BaseHelm(BaseK8S):
                             "nodeAgent.config.updatePeriod": self.filtered_sbom_update_time})
         
         HelmWrapper.install_armo_helm_chart(customer=self.backend.get_customer_guid() if self.backend != None else "",
-                                            environment=self.test_driver.backend_obj.get_name() if self.backend != None else "",
+                                            server=self.test_driver.backend_obj.get_api_url(),
                                             cluster_name=self.kubernetes_obj.get_cluster_name(),
                                             repo=self.helm_armo_repo, helm_kwargs=helm_kwargs)
         self.remove_armo_system_namespace = True

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -401,7 +401,7 @@ class BaseKubescape(BaseK8S):
 
         # build kubescape (make file) for non-windows machines
         if platform.system() != "Windows" and os.path.exists(os.path.join(ks_path, "Makefile")):
-            return_code, return_obj = TestUtil.run_command(command_args=["make"], cwd=ks_path, timeout=360)
+            return_code, return_obj = TestUtil.run_command(command_args=["make"], cwd=ks_path, timeout=1000)
             assert not return_code, f"Failed to build kubescape (make) from branch {branch} : {return_obj.stderr}"
             shutil.move(os.path.join(ks_path, "kubescape"), kubescape_exec)
         else:

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -80,7 +80,9 @@ class BaseKubescape(BaseK8S):
         self.artifacts = self.test_driver.kwargs.get("use_artifacts", None)
         self.policies = self.test_driver.kwargs.get("use_from", None)
         self.kubescape_exec = self.test_driver.kwargs.get("kubescape", None)
-        self.environment = '' if self.test_driver.backend_obj == None or self.test_driver.backend_obj.get_name() == "production" else self.test_driver.backend_obj.get_name()
+        if self.test_driver.backend_obj == None:
+            raise Exception('backend_obj must be specified')
+        self.api_url = self.test_driver.backend_obj.get_api_url()
         self.host_scan_yaml = self.test_driver.kwargs.get("host_scan_yaml", None)
         self.remove_cluster_from_backend = False
 
@@ -151,12 +153,8 @@ class BaseKubescape(BaseK8S):
         command.extend(['--output', output_file])
         if "account" in kwargs:
             command.extend(["--account", self.backend.get_customer_guid()])
-        if self.environment == "dev" or self.environment == "development":
-            command.extend(["--env", "dev"])
-        if self.environment == "staging" or self.environment == "stage":
-            command.extend(["--env", "report-ks.eustage2.cyberarmorsoft.com,api-stage.armosec.io,"
-                                     "cloud-stage.armosec.io,eggauth-stage.armosec.io"])
-
+        command.extend(["--server", self.api_url])
+        
         Logger.logger.info(" ".join(command))
         status_code, res = TestUtil.run_command(command_args=command, timeout=360,
                                                 stderr=TestUtil.get_arg_from_dict(kwargs, "stderr", None),
@@ -233,12 +231,7 @@ class BaseKubescape(BaseK8S):
             assert account_id, "missing account ID, the report will not be submitted"
             command.extend(["--account", self.backend.get_customer_guid()])
 
-        if self.environment == "staging" or self.environment == "stage":
-            command.extend(["--env", "report-ks.eustage2.cyberarmorsoft.com,api-stage.armosec.io,"
-                                     "cloud-stage.armosec.io,eggauth-stage.armosec.io"])
-
-        if self.environment == "dev" or self.environment == "development":
-            command.extend(["--env", "dev"])
+        command.extend(["--server", self.api_url])
 
         # first check if artifacts are passed to function
         if "use_artifacts" in kwargs and kwargs['use_artifacts'] != "":

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -76,7 +76,7 @@ class BaseKubescape(BaseK8S):
         super().__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
                          kubernetes_obj=kubernetes_obj)
 
-        self.ks_branch = self.test_driver.kwargs.get("ks_branch", "service-discovery")
+        self.ks_branch = self.test_driver.kwargs.get("ks_branch", DEFAULT_BRANCH)
         self.artifacts = self.test_driver.kwargs.get("use_artifacts", None)
         self.policies = self.test_driver.kwargs.get("use_from", None)
         self.kubescape_exec = self.test_driver.kwargs.get("kubescape", None)

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -76,7 +76,7 @@ class BaseKubescape(BaseK8S):
         super().__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
                          kubernetes_obj=kubernetes_obj)
 
-        self.ks_branch = self.test_driver.kwargs.get("ks_branch", DEFAULT_BRANCH)
+        self.ks_branch = self.test_driver.kwargs.get("ks_branch", "service-discovery")
         self.artifacts = self.test_driver.kwargs.get("use_artifacts", None)
         self.policies = self.test_driver.kwargs.get("use_from", None)
         self.kubescape_exec = self.test_driver.kwargs.get("kubescape", None)

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -204,7 +204,7 @@ class BaseKubescape(BaseK8S):
     def scan(self, policy_scope: str = None, policy_name: str = None, output_format: str = None, output: str = None,
              **kwargs):
 
-        command = [self.kubescape_exec, "scan", "--format-version", "v2"]
+        command = [self.kubescape_exec, "scan", "--logger", "debug", "--format-version", "v2"]
 
         if policy_scope:
             command.append(policy_scope)


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR introduces several changes to enhance the support for the new Helm chart and Kubescape version. It includes the addition of an `api_url` attribute to the `Backend` class and its usage in various functions. The environment-specific logic in the `install_armo_helm_chart` and `download_policy` functions has been refactored to use the `api_url` instead. The PR also includes changes to the `scan` function and an increase in the timeout for the `make` command in the `download_from_branch` function.

___
## PR Main Files Walkthrough:
`configurations/system/backends.py`: Added `api_url` attribute to the `Backend` class and updated the `set_backends` function to include `api_url` for different environments.
`infrastructure/helm_wrapper.py`: Refactored `install_armo_helm_chart` function to use `api_url` instead of environment-specific logic. Removed the environment-specific settings.
`tests_scripts/helm/base_helm.py`: Updated the call to `install_armo_helm_chart` function to pass `api_url` instead of environment name.
`tests_scripts/kubescape/base_kubescape.py`: Refactored `download_policy` and `scan` functions to use `api_url` instead of environment-specific logic. Increased the timeout for the `make` command in the `download_from_branch` function.
