### PR TITLE
Support kubescape-operator helm chart

### DIFF
--- a/configurations/system/tests_cases/vulnerability_scanning_tests.py
+++ b/configurations/system/tests_cases/vulnerability_scanning_tests.py
@@ -27,7 +27,7 @@ class VulnerabilityScanningTests(object):
             expected_results="wikijs.json",
             proxy_config={"helm_proxy_url":statics.HELM_PROXY_URL}
         )
-    
+
     @staticmethod
     def vulnerability_scanning():
         from tests_scripts.helm.vulnerability_scanning import VulnerabilityScanning
@@ -42,6 +42,7 @@ class VulnerabilityScanningTests(object):
             deployments=join(DEFAULT_DEPLOYMENT_PATH, "wikijs"),
             database=supported_systemsAPI.WikiJS,
             expected_results="wikijs.json",
+            helm_kwargs={statics.HELM_RELEVANCY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED},
             create_test_tenant=True
         )
 
@@ -143,7 +144,7 @@ class VulnerabilityScanningTests(object):
             expected_layers="layers.json"
         )
 
-        
+
 
     @staticmethod
     def vulnerability_scanning_triggering_with_cron_job():
@@ -193,7 +194,7 @@ class VulnerabilityScanningTests(object):
             test_obj=VulnerabilityScanningTestRegistryConnectivity,
         )
 
-    
+
     @staticmethod
     def vulnerability_scanning_test_public_registry_connectivity_excluded_by_backend():
         from tests_scripts.helm.vulnerability_scanning import VulnerabilityScanningTestRegistryConnectivity

--- a/systest_utils/statics.py
+++ b/systest_utils/statics.py
@@ -107,8 +107,8 @@ K8S_API_SERVER_CONTAINER_NAME = "kube-apiserver"
 KS_PORT_FORWARD = 33334
 
 # kubernetes cluster - armo-system
-HELM_REPO_FROM_LOCAL = "charts/kubescape-cloud-operator"
-HELM_REPO = "kubescape/kubescape-cloud-operator"
+HELM_REPO_FROM_LOCAL = "charts/kubescape-operator"
+HELM_REPO = "kubescape/kubescape-operator"
 CA_NAMESPACE_NAME = "kubescape"
 CA_NAMESPACE_FROM_HELM_NAME = "kubescape"
 CA_KUBESCAPE_CONFIGMAP_NAME = "kubescape-config"

--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -621,9 +621,9 @@ class BaseVulnerabilityScanning(BaseHelm):
         download_url = 'https://raw.githubusercontent.com/kubescape/helm-charts/gh-pages/index.yaml'
         helm_index = yaml.load(requests.get(download_url).content, Loader=yaml.FullLoader)
         version = "undefined"
-        if "entries" in helm_index and "kubescape-cloud-operator" in helm_index["entries"]:
-            if len(helm_index["entries"]["kubescape-cloud-operator"]) > 0:
-                version = helm_index["entries"]["kubescape-cloud-operator"][0]["version"]
+        if "entries" in helm_index and "kubescape-operator" in helm_index["entries"]:
+            if len(helm_index["entries"]["kubescape-operator"]) > 0:
+                version = helm_index["entries"]["kubescape-operator"][0]["version"]
 
         return version
 


### PR DESCRIPTION
Support changes introduced by https://github.com/kubescape/helm-charts/pull/262

## PR Type:
Refactoring

___
## PR Description:
This PR updates the references to the Kubescape Operator Helm chart in the codebase. The Helm chart name has been changed from 'kubescape-cloud-operator' to 'kubescape-operator'. This change is reflected in the 'systest_utils/statics.py' and 'tests_scripts/helm/base_vulnerability_scanning.py' files.

___
## PR Main Files Walkthrough:
`systest_utils/statics.py`: The constants HELM_REPO_FROM_LOCAL and HELM_REPO have been updated to reflect the new Helm chart name 'kubescape-operator'.
`tests_scripts/helm/base_vulnerability_scanning.py`: The method 'get_latest_helm_version' has been updated to fetch the latest version of the 'kubescape-operator' Helm chart instead of the old 'kubescape-cloud-operator' chart.
