### PR TITLE
fix don't fail on cleanup

### DIFF
--- a/tests_scripts/kubescape/scan.py
+++ b/tests_scripts/kubescape/scan.py
@@ -764,7 +764,10 @@ class ScanGitRepositoryAndSubmit(BaseKubescape):
         assert actual == expected, f"last report GUID of repository was not updated in portal expected: {expected} actual: {actual}"
         
         Logger.logger.info(f"Running test cleanup - deleting repository ({repoHash})")
-        self.backend.delete_repository(repository_hash=repoHash)
+        try:
+            self.backend.delete_repository(repository_hash=repoHash)
+        except Exception as e:
+            Logger.logger.warning(f"failed to delete repository - {e}")
         return statics.SUCCESS, ""
 
 class TestScanningScope(BaseKubescape):


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses an issue where the test cleanup process could fail if there was an error during the repository deletion. Now, the deletion process is wrapped in a try/except block to catch and log any exceptions, preventing the test from failing due to cleanup issues.

___
## PR Main Files Walkthrough:
`tests_scripts/kubescape/scan.py`: Added a try/except block around the repository deletion process during test cleanup to catch and log any exceptions, preventing test failure due to cleanup issues.

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
