### PR TITLE
Fix configurations test

### DIFF
--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -978,6 +978,11 @@ class BaseKubescape(BaseK8S):
         customer_configuration[_SETTINGS_FILED][_POSTURE_CONTROL_INPUT_FILED][input_kind].append(input_name)
         self.update_customer_configuration(customer_config=customer_configuration)
 
+    def remove_from_customer_configuration(self, customer_configuration: dict, input_kind: str, input_name: str):
+        if input_name in customer_configuration[_SETTINGS_FILED][_POSTURE_CONTROL_INPUT_FILED][input_kind]:
+            customer_configuration[_SETTINGS_FILED][_POSTURE_CONTROL_INPUT_FILED][input_kind].remove(input_name)
+        self.update_customer_configuration(customer_config=customer_configuration)
+
     def test_expected_result_against_cli_result(self, cli_result: dict, expected_result_name: str):
         expected_r = self.create_kubescape_expected_results(expected_results=expected_result_name)
         cli_r = cli_result[_CLI_SUMMARY_DETAILS_FIELD]

--- a/tests_scripts/kubescape/scan.py
+++ b/tests_scripts/kubescape/scan.py
@@ -456,6 +456,14 @@ class CustomerConfiguration(BaseKubescape):
         self.install(branch=self.ks_branch)
         files = BaseKubescape.get_abs_path(statics.DEFAULT_INPUT_YAML_PATH, self.test_obj.get_arg("yaml"))
 
+        Logger.logger.info("Stage 1.1: Apply empty customer configuration to backend")
+        self.original_customer_configuration = self.get_customer_configuration()
+        self.original_customer_configuration['name'] = 'CustomerConfig'
+        self.original_customer_configuration['attributes'] = {}
+        self.remove_from_customer_configuration(customer_configuration=copy.deepcopy(self.original_customer_configuration),
+                                             input_kind=self.test_obj.get_arg('input_kind'),
+                                                input_name=self.test_obj.get_arg('input_name'))
+        
         Logger.logger.info("Stage 1.1: Scan yaml file")
         result = self.default_scan(policy_scope=self.test_obj.policy_scope, policy_name=self.test_obj.policy_name,
                                    submit=self.test_obj.get_arg("submit"), account=self.test_obj.get_arg("account"),

--- a/tests_scripts/kubescape/scan.py
+++ b/tests_scripts/kubescape/scan.py
@@ -464,12 +464,12 @@ class CustomerConfiguration(BaseKubescape):
                                              input_kind=self.test_obj.get_arg('input_kind'),
                                                 input_name=self.test_obj.get_arg('input_name'))
         
-        Logger.logger.info("Stage 1.1: Scan yaml file")
+        Logger.logger.info("Stage 1.2: Scan yaml file")
         result = self.default_scan(policy_scope=self.test_obj.policy_scope, policy_name=self.test_obj.policy_name,
                                    submit=self.test_obj.get_arg("submit"), account=self.test_obj.get_arg("account"),
                                    yamls=files)
         TestUtil.sleep(25, "wait for kubescape scan to report", "info")    
-        Logger.logger.info("Stage 1.2: Test expected result that control X without configuration Y skipped")
+        Logger.logger.info("Stage 1.3: Test expected result that control X without configuration Y skipped")
         self.test_customer_configuration_result(cli_result=result, expected_result='skipped',
                                                 c_id=self.test_obj.policy_name)
 


### PR DESCRIPTION
## PR Type:
Tests, Enhancement

___
## PR Description:
This PR enhances the configuration tests in Kubescape by adding a method to remove a specific configuration from the customer's settings. It also updates the scan test to apply an empty customer configuration to the backend before scanning a YAML file. This ensures that the test checks the expected result that a control without a specific configuration is skipped.

___
## PR Main Files Walkthrough:
`tests_scripts/kubescape/base_kubescape.py`: Added a new method 'remove_from_customer_configuration' to remove a specific configuration from the customer's settings.
`tests_scripts/kubescape/scan.py`: Updated the 'start' method to apply an empty customer configuration to the backend before scanning a YAML file. This ensures that the test checks the expected result that a control without a specific configuration is skipped.
