### PR TITLE
fix: print last scan time

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -1976,7 +1976,7 @@ class ControlPanelAPI(object):
             last_scan_datetime = datetime.strptime(response['response']['attackChainsLastScan'], '%Y-%m-%dT%H:%M:%SZ')
             last_scan_datetime = last_scan_datetime.replace(tzinfo=timezone.utc)
             current_datetime_utc = current_datetime.astimezone(tz=timezone.utc)
-            print("last scan time: ", response['response']['attackChainsLastScan'])
+            print("last scan time: ", last_scan_datetime)
             print("current time: ", current_datetime_utc)
 
             assert last_scan_datetime >= current_datetime_utc, f"attack-chains response is outdated"


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a bug in the backend API where the last scan time was being printed in a non-standard format. The fix involves converting the last scan time to a datetime object in UTC format before printing.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`infrastructure/backend_api.py`: The last scan time, previously printed directly from the response, is now first converted to a datetime object in UTC format before being printed. This ensures that the time is displayed in a standard, universally understandable format.
</details>
