### PR TITLE
Support revert-discovery-job branch of helm-charts

### DIFF
--- a/configurations/system/backends.py
+++ b/configurations/system/backends.py
@@ -8,6 +8,8 @@ class Backend(object):
                  name: str, 
                  dashboard: str, 
                  api_url: str,
+                 sd_services: str,
+                 sd_metrics: str,
                  auth_url: str = None, 
                  tls_verify: bool = True, 
                  login_method = LOGIN_METHOD_KEYCLOAK, customer_guid: str = None):
@@ -18,6 +20,8 @@ class Backend(object):
         self.login_method = login_method
         self.customer_guid = customer_guid
         self.api_url = api_url
+        self.sd_services = sd_services
+        self.sd_metrics = sd_metrics
 
     def get_dashboard_url(self):
         return self.dashboard
@@ -39,6 +43,12 @@ class Backend(object):
 
     def get_api_url(self):
         return self.api_url
+    
+    def get_sd_services(self):
+        return self.sd_services
+    
+    def get_sd_metrics(self):
+        return self.sd_metrics
 
 
 def set_backends():
@@ -49,6 +59,8 @@ def set_backends():
     backends.append(Backend(name='development',
                             dashboard='https://eggdashbe-dev.armosec.io',
                             api_url="api-dev.armosec.io",
+                            sd_metrics="otelcol-dev.armosec.io:443",
+                            sd_services='{"version":"v1","response":{"event-receiver-http":"https://report.eudev3.cyberarmorsoft.com","event-receiver-ws":"wss://report.eudev3.cyberarmorsoft.com","gateway":"wss://ens.eudev3.cyberarmorsoft.com","api-server":"https://api-dev.armosec.io","metrics":"otelcol-dev.armosec.io:443"}}',
                             auth_url='https://eggauth-dev.armosec.io',
                             tls_verify=False,
                             login_method=LOGIN_METHOD_FRONTEGG_SECRET))
@@ -57,6 +69,8 @@ def set_backends():
     # staging frontEgg
     backends.append(Backend(name='staging',
                             dashboard='https://eggdashbe-stage.armosec.io',
+                            sd_metrics="otelcol-dev.armosec.io:443",
+                            sd_services='{"version":"v1","response":{"event-receiver-http":"https://report-ks.eustage2.cyberarmorsoft.com","event-receiver-ws":"wss://report-ks.eustage2.cyberarmorsoft.com","gateway":"wss://ens.eustage2.cyberarmorsoft.com","api-server":"https://api-stage.armosec.io","metrics":"otelcol-dev.armosec.io:443"}}',
                             api_url="api-stage.armosec.io",
                             auth_url='https://eggauth-stage.armosec.io',
                             tls_verify=False,
@@ -65,6 +79,8 @@ def set_backends():
     # staging frontEgg
     backends.append(Backend(name='production',
                             api_url="api.armosec.io",
+                            sd_metrics="otelcol.armosec.io:443",
+                            sd_services='{"version":"v1","response":{"event-receiver-http":"https://report.armo.cloud","event-receiver-ws":"wss://report.armo.cloud","gateway":"wss://ens.euprod1.cyberarmorsoft.com","api-server":"https://api.armosec.io","metrics":"otelcol.armosec.io:443"}}',
                             dashboard='https://api.armosec.io',
                             auth_url='https://auth.armosec.io',
                             tls_verify=False,
@@ -108,6 +124,8 @@ def set_backends():
     backends.append(Backend(name='local',
                             api_url="localhost:7666",
                             dashboard='http://localhost:7666',
+                            sd_metrics="",
+                            sd_services="",
                             auth_url='https://eggauth-dev.armosec.io',
                             tls_verify=False,
                             login_method=LOGIN_METHOD_FRONTEGG_USERNAME,

--- a/infrastructure/helm_wrapper.py
+++ b/infrastructure/helm_wrapper.py
@@ -27,11 +27,14 @@ class HelmWrapper(object):
 
     @staticmethod
     def install_armo_helm_chart(customer: str, server: str, cluster_name: str,
+                                metrics: str, services: str,
                                 repo: str=statics.HELM_REPO, helm_kwargs:dict={}):
         command_args = ["helm", "upgrade", "--debug", "--install", "kubescape", repo, "-n", statics.CA_NAMESPACE_FROM_HELM_NAME,
                         "--create-namespace",
                         "--set", "account={x}".format(x=customer),
                         "--set", "server={x}".format(x=server),
+                        "--set-literal", "serviceDiscovery.services={x}".format(x=services),
+                        "--set", "serviceDiscovery.metrics={x}".format(x=metrics),
                         "--set", "clusterName={}".format(cluster_name), "--set", "logger.level=debug"]
 
         # by default use offline vuln DB

--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -118,6 +118,8 @@ class BaseHelm(BaseK8S):
         
         HelmWrapper.install_armo_helm_chart(customer=self.backend.get_customer_guid() if self.backend != None else "",
                                             server=self.test_driver.backend_obj.get_api_url(),
+                                            services=self.test_driver.backend_obj.get_sd_services(),
+                                            metrics=self.test_driver.backend_obj.get_sd_metrics(),
                                             cluster_name=self.kubernetes_obj.get_cluster_name(),
                                             repo=self.helm_armo_repo, helm_kwargs=helm_kwargs)
         self.remove_armo_system_namespace = True


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces support for service discovery in Helm charts. It adds two new parameters, 'sd_services' and 'sd_metrics', to the Backend class in the 'configurations/system/backends.py' file. These parameters are then used in the 'install_armo_helm_chart' method in both 'infrastructure/helm_wrapper.py' and 'tests_scripts/helm/base_helm.py' files to set the 'serviceDiscovery.services' and 'serviceDiscovery.metrics' values when installing the Helm chart.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`configurations/system/backends.py`: Added 'sd_services' and 'sd_metrics' parameters to the Backend class. These parameters are used to store the service discovery services and metrics URLs respectively. Also, added these parameters to the 'set_backends' method for each backend.
`infrastructure/helm_wrapper.py`: Modified the 'install_armo_helm_chart' method to include 'services' and 'metrics' parameters. These parameters are used to set the 'serviceDiscovery.services' and 'serviceDiscovery.metrics' values when installing the Helm chart.
`tests_scripts/helm/base_helm.py`: Modified the 'install_armo_helm_chart' method to include 'services' and 'metrics' parameters. These parameters are used to set the 'serviceDiscovery.services' and 'serviceDiscovery.metrics' values when installing the Helm chart.
</details>

___
## User Description:
Needed for the following changes:
https://github.com/kubescape/helm-charts/pull/295
