### PR TITLE
Do not assert on more than one connected cluster

### DIFF
--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -587,7 +587,7 @@ class BaseVulnerabilityScanning(BaseHelm):
         assert cluster_info['lastReconnected'] != _UNSET_DATE
         assert cluster_info['lastDisconnected'] == _UNSET_DATE
         assert cluster_info['disconnectionCount'] == 0
-        assert cluster_info['connectionCount'] == 1
+        assert cluster_info['connectionCount'] >= 1
         assert parse_version(cluster_info['helmChartVersionInfo']['latest']) <= parse_version(self.get_latest_helm_version()), f"cluster_info: {cluster_info['helmChartVersionInfo']['latest']}, helm version: {self.get_latest_helm_version()}"
         assert parse_version(helm_chart_version) >= parse_version(cluster_info['helmChartVersionInfo']['current']) , f"cluster_info: {helm_chart_version}, helm version: {cluster_info['helmChartVersionInfo']['current']}"
         assert parse_version(cluster_info['latestHelmChartVersion']) <= parse_version(self.get_latest_helm_version()) , f"cluster_info: {cluster_info['latestHelmChartVersion']}, helm version: {self.get_latest_helm_version()}"


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR modifies an assertion in the `test_cluster_info` function within the `base_vulnerability_scanning.py` test script. Previously, the test asserted that the `connectionCount` should be exactly 1. This PR changes the assertion to check that the `connectionCount` is greater than or equal to 1, allowing for multiple connections.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`tests_scripts/helm/base_vulnerability_scanning.py`: The assertion for `connectionCount` in the `test_cluster_info` function has been updated from `== 1` to `>= 1`, allowing for the possibility of more than one connection.
</details>
