### PR TITLE
Update base_vulnerability_scanning.py

### DIFF
--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -599,7 +599,7 @@ class BaseVulnerabilityScanning(BaseHelm):
         assert cluster_info['attributes']['description'] == 'created by Kubescape automatically', \
             'The cluster description is not created by Kubescape automatically'
         assert cluster_info['attributes']['createdBy'] == 'armo-aggregator', \
-            'The cluster created by is not armo-aggregator'
+             f"The cluster created by is not armo-aggregator. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
         assert 'latest' in cluster_info['kubescapeVersion'], f"invalid cluster_info {cluster_info}"
         assert parse_version(cluster_info['kubescapeVersion']['latest']) <= parse_version(
             self.get_latest_kubescape_version()), f"cluster_info: {cluster_info['kubescapeVersion']['latest']}, kubescape version: {self.get_latest_kubescape_version()}"


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR refines the error message in the `test_cluster_info` method of the `base_vulnerability_scanning.py` test script. The updated error message now includes the actual value of `createdBy` attribute when the assertion fails, providing more context for debugging.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`tests_scripts/helm/base_vulnerability_scanning.py`: The error message in the assertion checking the 'createdBy' attribute of the cluster info has been updated to include the actual value of 'createdBy' when the assertion fails. This change provides more context for debugging when the test fails.
</details>
