### PR TITLE
Update base_vulnerability_scanning.py

### DIFF
--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -579,7 +579,6 @@ class BaseVulnerabilityScanning(BaseHelm):
         cluster_name=self.kubernetes_obj.get_cluster_name()
         cluster_info = self.get_cluster_with_risk_status(cluster_name=cluster_name)
         Logger.logger.info("cluster_info: %s", cluster_info)
-        Logger.logger.info("cluster_info_attributes_createdBy: %s",cluster_info['attributes']['createdBy'])
         helm_chart_version = cluster_info['helmChartVersion']
         assert helm_chart_version != ''
         assert cluster_info['installationData']['clusterName'] == cluster_name
@@ -598,8 +597,8 @@ class BaseVulnerabilityScanning(BaseHelm):
         assert cluster_info['attributes']['kind'] == 'k8s', 'The cluster kind is not k8s'
         assert cluster_info['attributes']['description'] == 'created by Kubescape automatically', \
             'The cluster description is not created by Kubescape automatically'
-        assert cluster_info['attributes']['createdBy'] == 'armo-aggregator', \
-             f"The cluster created by is not armo-aggregator. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
+        assert cluster_info['attributes']['createdBy'] == 'armo-aggregator' || cluster_info['attributes']['createdBy'] == 'armo-ingesters', \
+             f"The cluster created by is not armo-aggregator or armo-ingesters. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
         assert 'latest' in cluster_info['kubescapeVersion'], f"invalid cluster_info {cluster_info}"
         assert parse_version(cluster_info['kubescapeVersion']['latest']) <= parse_version(
             self.get_latest_kubescape_version()), f"cluster_info: {cluster_info['kubescapeVersion']['latest']}, kubescape version: {self.get_latest_kubescape_version()}"


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR refactors the `test_cluster_info` method in the `base_vulnerability_scanning.py` file. The changes include the removal of a log statement and the modification of an assertion to allow for two possible creators of the cluster, 'armo-aggregator' or 'armo-ingesters'.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`tests_scripts/helm/base_vulnerability_scanning.py`: The `test_cluster_info` method has been updated. A log statement printing the 'createdBy' attribute of the cluster_info object has been removed. The assertion checking the 'createdBy' attribute of the cluster_info object has been modified to check for either 'armo-aggregator' or 'armo-ingesters'.
</details>
