### PR TITLE
Update base_vulnerability_scanning.py

### DIFF
--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -597,8 +597,8 @@ class BaseVulnerabilityScanning(BaseHelm):
         assert cluster_info['attributes']['kind'] == 'k8s', 'The cluster kind is not k8s'
         assert cluster_info['attributes']['description'] == 'created by Kubescape automatically', \
             'The cluster description is not created by Kubescape automatically'
-        assert cluster_info['attributes']['createdBy'] == 'armo-aggregator' || cluster_info['attributes']['createdBy'] == 'armo-ingesters', \
-             f"The cluster created by is not armo-aggregator or armo-ingesters. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
+        assert cluster_info['attributes']['createdBy'] == 'armo-ingesters', \
+             f"The cluster created by is not armo-ingesters. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
         assert 'latest' in cluster_info['kubescapeVersion'], f"invalid cluster_info {cluster_info}"
         assert parse_version(cluster_info['kubescapeVersion']['latest']) <= parse_version(
             self.get_latest_kubescape_version()), f"cluster_info: {cluster_info['kubescapeVersion']['latest']}, kubescape version: {self.get_latest_kubescape_version()}"


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR refines the assertion check for the 'createdBy' attribute in the 'test_cluster_info' function of the 'base_vulnerability_scanning.py' test script. The change ensures that the 'createdBy' attribute is strictly checked to be 'armo-ingesters' instead of either 'armo-aggregator' or 'armo-ingesters'.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`tests_scripts/helm/base_vulnerability_scanning.py`: The assertion check for the 'createdBy' attribute in the 'test_cluster_info' function has been updated. Previously, the test would pass if 'createdBy' was either 'armo-aggregator' or 'armo-ingesters'. Now, the test will only pass if 'createdBy' is 'armo-ingesters'.
</details>
