### PR TITLE
Adding Cronjob Tests to Attack Chains Suite

### DIFF
--- a/configurations/system/tests_cases/ks_microservice_test.py
+++ b/configurations/system/tests_cases/ks_microservice_test.py
@@ -74,6 +74,22 @@ class KSMicroserviceTests(object):
         )
 
     @staticmethod
+    def scan_for_attack_chains_scenario_alpine_fix_image_with_relevancy_with_cronjob():
+        """
+        install scenario 'alpine' on the cluster, install the kubescape operator and run the scan triggered by a cronjob.
+        once the attack chain has been detected on the backend, fix the attack chain and verify that is has been solved 
+        by triggering a new image scan.
+        """
+        from tests_scripts.helm.ks_microservice import ScanAttackChainsWithKubescapeHelmChart
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=ScanAttackChainsWithKubescapeHelmChart,
+            test_job=[{"trigger_by": "cronjob", "operation": "create", "framework": [""], "hostsensor": True}],
+            test_scenario="alpine",
+            fix_object="image"
+        )
+
+    @staticmethod
     def scan_for_attack_chains_scenario_alpine_fix_control_with_relevancy():
         """
         install scenario 'alpine' on the cluster, install the kubescape operator and run the scan.
@@ -101,6 +117,24 @@ class KSMicroserviceTests(object):
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanAttackChainsWithKubescapeHelmChart,
             test_job=[{"trigger_by": "scan_on_start"}],
+            test_scenario="alpine",
+            fix_object="image",
+            helm_kwargs={statics.HELM_RELEVANCY_FEATURE: statics.HELM_RELEVANCY_FEATURE_DISABLED},
+            relevancy_enabled=False
+        )
+
+    @staticmethod
+    def scan_for_attack_chains_scenario_alpine_fix_image_no_relevancy_with_cronjob():
+        """
+        install scenario 'alpine' on the cluster, install the kubescape operator disabling relevancy and run the scan triggered by a cronjob.
+        once the attack chain has been detected on the backend, fix the attack chain and verify that is has been solved 
+        by triggering a new image scan.
+        """
+        from tests_scripts.helm.ks_microservice import ScanAttackChainsWithKubescapeHelmChart
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=ScanAttackChainsWithKubescapeHelmChart,
+            test_job=[{"trigger_by": "cronjob", "operation": "create", "framework": [""], "hostsensor": True}],
             test_scenario="alpine",
             fix_object="image",
             helm_kwargs={statics.HELM_RELEVANCY_FEATURE: statics.HELM_RELEVANCY_FEATURE_DISABLED},

--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -1973,9 +1973,8 @@ class ControlPanelAPI(object):
         # checks if respose met conditions to be considered valid:
         # - parameter 'response.attackChainsLastScan' should have a value >= of current time
         # - parameter 'total.value' shoud be > 0
-        #TestUtil.run_command(command_args="kubectl get pods -n kubescape", display_stdout=True, timeout=300)
-        result = subprocess.run("kubectl get pods -A", timeout=300, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        print(result.stdout)
+        #result = subprocess.run("kubectl get pods -A", timeout=300, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        #print(result.stdout)
         response = json.loads(r.text)
         if response['response']['attackChainsLastScan']:
             last_scan_datetime = datetime.strptime(response['response']['attackChainsLastScan'], '%Y-%m-%dT%H:%M:%SZ')

--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,10 @@
 | `scan_for_attack_chains_scenario_1_1_fix_control_no_relevancy`                | helm-chart |                                    | in-cluster kubescape, backend |
 | `scan_for_attack_chains_scenario_1_1_fix_control_with_relevancy`                | helm-chart |                                    | in-cluster kubescape, backend |
 | `scan_for_attack_chains_scenario_alpine_fix_image_with_relevancy`             | helm-chart |                                    | in-cluster kubescape, backend |
+| `scan_for_attack_chains_scenario_alpine_fix_image_with_relevancy_with_cronjob`             | helm-chart |                                    | in-cluster kubescape, backend |
 | `scan_for_attack_chains_scenario_alpine_fix_control_with_relevancy`             | helm-chart |                                    | in-cluster kubescape, backend |
 | `scan_for_attack_chains_scenario_alpine_fix_image_no_relevancy`             | helm-chart |                                    | in-cluster kubescape, backend |
+| `scan_for_attack_chains_scenario_alpine_fix_image_no_relevancy_with_cronjob`                | helm-chart |                                    | in-cluster kubescape, backend |
 | `ks_microservice_create_2_cronjob_mitre_and_nsa_proxy`               | helm-chart |                                                                        | in-cluster kubescape, backend |
 | `vulnerability_scanning_trigger_scan_public_registry`          | helm-chart |                                                                        | kubevuln, backend             |
 | `vulnerability_scanning_trigger_scan_public_registry_excluded` | helm-chart |                                                                        | kubevuln, backend             |


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR introduces new tests for the attack chains suite, specifically for scenarios triggered by a cronjob. The changes include the addition of two new test scenarios in the `ks_microservice_test.py` file, modifications to the `ks_microservice.py` file to handle the new trigger type, and updates to the `backend_api.py` file. The README has also been updated to reflect the new tests.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`configurations/system/tests_cases/ks_microservice_test.py`: Two new test scenarios have been added: `scan_for_attack_chains_scenario_alpine_fix_image_with_relevancy_with_cronjob` and `scan_for_attack_chains_scenario_alpine_fix_image_no_relevancy_with_cronjob`. These tests install the 'alpine' scenario on the cluster, run the scan triggered by a cronjob, fix the attack chain, and verify that it has been solved by triggering a new image scan.
`infrastructure/backend_api.py`: Removed a subprocess command that was used to get pods and print the result. This change simplifies the `get_active_attack_chains` function.
`tests_scripts/helm/ks_microservice.py`: The `start` function has been updated to accommodate the new trigger type. The `trigger_scan` function now takes an additional parameter, `trigger_by`, to determine the type of event that triggers the scan. The function has been updated to handle the new 'cronjob' trigger type.
`readme.md`: The new test scenarios `scan_for_attack_chains_scenario_alpine_fix_image_with_relevancy_with_cronjob` and `scan_for_attack_chains_scenario_alpine_fix_image_no_relevancy_with_cronjob` have been added to the list of test cases.
</details>
