### PR TITLE
Update base_vulnerability_scanning.py

### DIFF
--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -597,6 +597,8 @@ class BaseVulnerabilityScanning(BaseHelm):
         assert cluster_info['attributes']['kind'] == 'k8s', 'The cluster kind is not k8s'
         assert cluster_info['attributes']['description'] == 'created by Kubescape automatically', \
             'The cluster description is not created by Kubescape automatically'
+        assert (cluster_info['attributes']['createdBy'] == 'armo-ingesters' or cluster_info['attributes']['createdBy'] == 'armo-aggregator'), \
+            f"The cluster created by is not armo-ingesters or armo-aggs. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
         assert cluster_info['attributes']['createdBy'] == 'armo-ingesters', \
              f"The cluster created by is not armo-ingesters. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
         assert 'latest' in cluster_info['kubescapeVersion'], f"invalid cluster_info {cluster_info}"


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR enhances the test_cluster_info function in the base_vulnerability_scanning.py file. It adds an assertion to check if the 'createdBy' attribute of the cluster info is either 'armo-ingesters' or 'armo-aggregator'. This is in addition to the existing checks on other attributes of the cluster info.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`tests_scripts/helm/base_vulnerability_scanning.py`: Added an assertion to check the 'createdBy' attribute of the cluster info in the test_cluster_info function.
</details>
