### PR TITLE
Update base_vulnerability_scanning.py

### DIFF
--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -599,8 +599,6 @@ class BaseVulnerabilityScanning(BaseHelm):
             'The cluster description is not created by Kubescape automatically'
         assert (cluster_info['attributes']['createdBy'] == 'armo-ingesters' or cluster_info['attributes']['createdBy'] == 'armo-aggregator'), \
             f"The cluster created by is not armo-ingesters or armo-aggs. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
-        assert cluster_info['attributes']['createdBy'] == 'armo-ingesters', \
-             f"The cluster created by is not armo-ingesters. Cluster createdBy: {cluster_info['attributes']['createdBy']}"
         assert 'latest' in cluster_info['kubescapeVersion'], f"invalid cluster_info {cluster_info}"
         assert parse_version(cluster_info['kubescapeVersion']['latest']) <= parse_version(
             self.get_latest_kubescape_version()), f"cluster_info: {cluster_info['kubescapeVersion']['latest']}, kubescape version: {self.get_latest_kubescape_version()}"


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR refactors the `test_cluster_info` method in the `base_vulnerability_scanning.py` file. It removes a redundant assertion check for the 'createdBy' attribute of the cluster_info object.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`tests_scripts/helm/base_vulnerability_scanning.py`: Removed a redundant assertion check for the 'createdBy' attribute in the 'test_cluster_info' method. The 'createdBy' attribute is now only checked to be either 'armo-ingesters' or 'armo-aggregator'.
</details>
