### PR TITLE
Update base_vulnerability_scanning.py

### DIFF
--- a/tests_scripts/helm/base_vulnerability_scanning.py
+++ b/tests_scripts/helm/base_vulnerability_scanning.py
@@ -369,7 +369,7 @@ class BaseVulnerabilityScanning(BaseHelm):
 
         result = {}
         for container in container_scan_id:
-            container_cve, time = self.wait_for_report(timeout=800, report_type=self.backend.get_scan_results_details,
+            container_cve, time = self.wait_for_report(timeout=1250, report_type=self.backend.get_scan_results_details,
                                                        containers_scan_id=container[_CONTAINER_SCAN_ID],
                                                        since_time=since_time,
                                                        expected_results=expected_results[container[_CONTAINER_NAME]],
@@ -426,7 +426,7 @@ class BaseVulnerabilityScanning(BaseHelm):
 
         result = {}
         for container in container_scan_id:
-            container_cve, time = self.wait_for_report(timeout=600, report_type=self.backend.get_registry_container_cve,
+            container_cve, time = self.wait_for_report(timeout=1250, report_type=self.backend.get_registry_container_cve,
                                                        containers_scan_id=container[_IMAGE_TAG_SCAN_ID],
                                                        since_time=since_time, total_cve=container[_IMAGE_TAG_TOTAL_CVE])
             name = statics.SCAN_RESULT_NAME_FIELD
@@ -441,7 +441,7 @@ class BaseVulnerabilityScanning(BaseHelm):
 
     def test_all_images_vuln_scan_reported(self, in_cluster_images, since_time):
         for ns in in_cluster_images:
-            be_summary, _ = self.wait_for_report(timeout=1200, report_type=self.backend.get_scan_results_sum_summary,
+            be_summary, _ = self.wait_for_report(timeout=1250, report_type=self.backend.get_scan_results_sum_summary,
                                                  namespace=ns, since_time=since_time,
                                                  expected_results=len(in_cluster_images[ns]))
 
@@ -458,7 +458,7 @@ class BaseVulnerabilityScanning(BaseHelm):
 
         result = {}
         for container in container_scan_id:
-            container_cve, time = self.wait_for_report(timeout=600, report_type=self.backend.get_scan_results_details,
+            container_cve, time = self.wait_for_report(timeout=1250, report_type=self.backend.get_scan_results_details,
                                                        containers_scan_id=container[_CONTAINER_SCAN_ID],
                                                        since_time=since_time,
                                                        expected_results=expected_results[container[_CONTAINER_NAME]],
@@ -915,7 +915,7 @@ class BaseVulnerabilityScanning(BaseHelm):
     def test_cluster_deleted(self, since_time: str):
         cluster_result, _ = self.wait_for_report(report_type=self.backend.get_scan_results_sum_summary, namespace='',
                                                  expected_results=0, since_time=since_time, expected_status_code=404,
-                                                 cluster_name=self.kubernetes_obj.get_cluster_name(), timeout=600)
+                                                 cluster_name=self.kubernetes_obj.get_cluster_name(), timeout=1250)
         assert cluster_result, 'Failed to verify deleting cluster {x} from backend'. \
             format(x=self.kubernetes_obj.get_cluster_name())
 


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR increases the timeout value for various vulnerability scanning methods in the `base_vulnerability_scanning.py` script. This change is likely to provide more time for the scanning processes to complete, which could be beneficial in cases where the previous timeout was not sufficient.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`tests_scripts/helm/base_vulnerability_scanning.py`: The timeout parameter for the `wait_for_report` method has been increased from 800 to 1250 in the `get_container_cve` method, from 600 to 1250 in the `get_registry_container_cve` and `get_container_cve_without_filter_response` methods, from 1200 to 1250 in the `test_all_images_vuln_scan_reported` method, and from 600 to 1250 in the `test_cluster_deleted` method.
</details>
