### PR TITLE
support access keys

### DIFF
--- a/infrastructure/backendapi.md
+++ b/infrastructure/backendapi.md
@@ -90,8 +90,8 @@ This allows test isolation for a specifc tenant which can be easily deleted once
 
 In order to populate the selected tenant, best practice will be to first create it and then "select" it:
 
-```go
-res, test_tenant_id = self.backend.create_tenant(tenantName)
+```python
+test_tenant_id, test_tenant_access_key = self.backend.create_tenant(tenantName)
 self.backend.select_tenant(test_tenant_id)
 ```
 
@@ -99,7 +99,7 @@ Once the tenant is selected, all apis calls will use it's cookie (selected_tenan
 
 At the end of the test, need to delete the selected tenant:
 
-```go
+```python
 self.backend.delete_tenant(tenant_id)
 ```
 

--- a/infrastructure/helm_wrapper.py
+++ b/infrastructure/helm_wrapper.py
@@ -26,13 +26,16 @@ class HelmWrapper(object):
         # os.system("helm repo update armo")
 
     @staticmethod
-    def install_armo_helm_chart(customer: str, server: str, cluster_name: str,
+    def install_armo_helm_chart(customer: str, access_key: str, server: str, cluster_name: str,
                                 repo: str=statics.HELM_REPO, helm_kwargs:dict={}):
         command_args = ["helm", "upgrade", "--debug", "--install", "kubescape", repo, "-n", statics.CA_NAMESPACE_FROM_HELM_NAME,
                         "--create-namespace",
                         "--set", "account={x}".format(x=customer),
                         "--set", "server={x}".format(x=server),
                         "--set", "clusterName={}".format(cluster_name), "--set", "logger.level=debug"]
+
+        if access_key != "":
+            command_args.extend(["--set", "accessKey={x}".format(x=access_key)])
 
         # by default use offline vuln DB
         command_args.extend(["--set", f"{statics.HELM_OFFLINE_VULN_DB}=True"])

--- a/systest_utils/systests_utilities.py
+++ b/systest_utils/systests_utilities.py
@@ -234,13 +234,15 @@ class TestUtil(object):
         return False
 
     @staticmethod
-    def run_command(command_args: list, timeout=60, display_stdout: bool = True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd: str=""):
+    def run_command(command_args: list, timeout=60, display_stdout: bool = True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd: str="", env=None):
         if isinstance(command_args, str):
             command_args = command_args.split(" ")
         start = time.time()
         try:
-            return_obj = subprocess.run(command_args, timeout=timeout, stdout=stdout, stderr=stderr, cwd=cwd) if cwd \
-                else subprocess.run(command_args, timeout=timeout, stdout=stdout, stderr=stderr)
+            if env is None:
+                env = {}
+            return_obj = subprocess.run(command_args, timeout=timeout, stdout=stdout, stderr=stderr, cwd=cwd, env=env) if cwd \
+                else subprocess.run(command_args, timeout=timeout, stdout=stdout, stderr=stderr, env=env)
         except Exception as e:
             Logger.logger.error(e)
             raise Exception(e)

--- a/tests_scripts/base_test.py
+++ b/tests_scripts/base_test.py
@@ -87,7 +87,8 @@ class BaseTest(object):
         # prefix = self.__class__.__name__ if prefix is None else prefix + self.__class__.__name__
         prefix = prefix if prefix is not None else ""
         tenantName = self.create_tenant_name(prefix)
-        res, test_tenant_id = self.backend.create_tenant(tenantName)
+        test_tenant_id, test_tenant_access_key = self.backend.create_tenant(tenantName)
+        self.backend.set_access_key(test_tenant_access_key)
         Logger.logger.info(f"created tenant name '{tenantName}' with tenant id {test_tenant_id}")
         self.backend.select_tenant(test_tenant_id)
         return test_tenant_id

--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -117,6 +117,7 @@ class BaseHelm(BaseK8S):
                             })
         
         HelmWrapper.install_armo_helm_chart(customer=self.backend.get_customer_guid() if self.backend != None else "",
+                                            access_key=self.backend.get_access_key() if self.backend != None else "",
                                             server=self.test_driver.backend_obj.get_api_url(),
                                             cluster_name=self.kubernetes_obj.get_cluster_name(),
                                             repo=self.helm_armo_repo, helm_kwargs=helm_kwargs)

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -151,12 +151,17 @@ class BaseKubescape(BaseK8S):
             command.append(policy_name)
 
         command.extend(['--output', output_file])
+
+        env = {}
         if "account" in kwargs:
             command.extend(["--account", self.backend.get_customer_guid()])
+            env = {"KS_ACCESS_KEY": self.backend.get_access_key()} if self.backend.get_access_key() != "" else {}
         command.extend(["--server", self.api_url])
         
         Logger.logger.info(" ".join(command))
-        status_code, res = TestUtil.run_command(command_args=command, timeout=360,
+        status_code, res = TestUtil.run_command(command_args=command,
+                                                env=env,
+                                                timeout=360,
                                                 stderr=TestUtil.get_arg_from_dict(kwargs, "stderr", None),
                                                 stdout=TestUtil.get_arg_from_dict(kwargs, "stdout", None))
         assert status_code == 0, res
@@ -203,7 +208,6 @@ class BaseKubescape(BaseK8S):
 
     def scan(self, policy_scope: str = None, policy_name: str = None, output_format: str = None, output: str = None,
              **kwargs):
-
         command = [self.kubescape_exec, "scan", "--logger", "debug", "--format-version", "v2"]
 
         if policy_scope:
@@ -224,12 +228,16 @@ class BaseKubescape(BaseK8S):
             command.extend(["--exceptions", kwargs['exceptions']])
         if "keep_local" in kwargs:
             command.append("--keep-local")
+        
+        env = {}
         if "submit" in kwargs:
             command.append("--submit")
             self.remove_cluster_from_backend = True
             account_id = kwargs["account"] if "account" in kwargs else self.backend.get_customer_guid()
             assert account_id, "missing account ID, the report will not be submitted"
             command.extend(["--account", self.backend.get_customer_guid()])
+            # set the access key with env var until it will be supported as a flag
+            env = {"KS_ACCESS_KEY": self.backend.get_access_key()} if self.backend.get_access_key() != "" else {}
 
         command.extend(["--server", self.api_url])
 
@@ -249,10 +257,6 @@ class BaseKubescape(BaseK8S):
             command.extend(["--include-namespaces", kwargs['include_namespaces']])
         if "enable_host_scan" in kwargs:
             command.append("--enable-host-scan")
-        if "client_id" in kwargs:
-            command.append(f"--client-id={self.backend.get_client_id()}")
-        if "secret_key" in kwargs:
-            command.append(f"--secret-key={self.backend.get_secret_key()}")
 
         if "host_scan_yaml" in kwargs and kwargs['host_scan_yaml'] != "":
             command.append(f"--host-scan-yaml={kwargs['host_scan_yaml']}")
@@ -263,7 +267,9 @@ class BaseKubescape(BaseK8S):
 
         Logger.logger.info(" ".join(command))
 
-        status_code, res = TestUtil.run_command(command_args=command, timeout=360,
+        status_code, res = TestUtil.run_command(command_args=command, 
+                                                env=env,
+                                                timeout=360,
                                                 stderr=TestUtil.get_arg_from_dict(kwargs, "stderr", None),
                                                 stdout=TestUtil.get_arg_from_dict(kwargs, "stdout", None))
         assert status_code == 0, res


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces support for access keys in the backend API. The main changes include:
- Adding an API endpoint for access keys.
- Modifying the login method to retrieve and set access keys.
- Updating the tenant creation method to return the tenant's access key.
- Adding a method to retrieve access keys.
- Updating various scripts to accommodate the use of access keys.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`infrastructure/backend_api.py`: Added an API endpoint for access keys. Modified the login method to retrieve and set access keys. Updated the tenant creation method to return the tenant's access key. Added a method to retrieve access keys.
`infrastructure/helm_wrapper.py`: Updated the method for installing the Armo Helm chart to include the access key.
`systest_utils/systests_utilities.py`: Updated the run_command method to accept an environment variable dictionary.
`tests_scripts/base_test.py`: Updated the method for creating a new tenant to set the access key.
`tests_scripts/helm/base_helm.py`: Updated the method for installing the Armo Helm chart to include the access key.
`tests_scripts/kubescape/base_kubescape.py`: Updated the methods for downloading policy and scanning to include the access key.
`infrastructure/backendapi.md`: Updated the documentation to reflect the changes made in the backend API related to access keys.
</details>
