### PR TITLE
Network policy

### DIFF
--- a/configurations/k8s_workloads/deployments/busybox/busybox.yaml
+++ b/configurations/k8s_workloads/deployments/busybox/busybox.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox
+        command: ["tail", "-f", "/dev/null"]

--- a/configurations/k8s_workloads/known-servers/known-server.json
+++ b/configurations/k8s_workloads/known-servers/known-server.json
@@ -1,0 +1,14 @@
+{
+  "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+  "kind": "KnownServer",
+  "metadata": {
+      "name": "github"
+  },
+  "spec": [
+      {
+          "ipBlock": "142.250.1.104/24",
+          "name": "github-workflows",
+          "server": "github.com"
+      }
+  ]
+}

--- a/configurations/network-policy/expected-generated-network-policy/busybox-known-server.json
+++ b/configurations/network-policy/expected-generated-network-policy/busybox-known-server.json
@@ -1,0 +1,111 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "GeneratedNetworkPolicy",
+    "metadata": {
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "busybox-deployment"
+        },
+        "name": "deployment-busybox-deployment",
+        "namespace": "systest-ns-d3qk"
+    },
+    "policyRef": [
+        {
+            "dns": "www.google.com.",
+            "ipBlock": "64.233.183.104/32",
+            "name": "",
+            "originalIP": "64.233.183.104",
+            "server": ""
+        },
+        {
+            "dns": "",
+            "ipBlock": "142.250.1.104/24",
+            "name": "github-workflows",
+            "originalIP": "142.250.1.104",
+            "server": "github.com"
+        }
+    ],
+    "spec": {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "annotations": {
+                "generated-by": "kubescape"
+            },
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "busybox-deployment"
+            },
+            "name": "deployment-busybox-deployment",
+            "namespace": "systest-ns-d3qk"
+        },
+        "spec": {
+            "egress": [
+                {
+                    "ports": [
+                        {
+                            "port": 53,
+                            "protocol": "UDP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "kubernetes.io/metadata.name": "kube-system"
+                                }
+                            },
+                            "podSelector": {
+                                "matchLabels": {
+                                    "k8s-app": "kube-dns"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ports": [
+                        {
+                            "port": 80,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "ipBlock": {
+                                "cidr": "64.233.183.104/32"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ports": [
+                        {
+                            "port": 80,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "ipBlock": {
+                                "cidr": "142.250.1.104/24"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "podSelector": {
+                "matchLabels": {
+                    "app": "busybox"
+                }
+            },
+            "policyTypes": [
+                "Egress"
+            ]
+        }
+    }
+}

--- a/configurations/network-policy/expected-generated-network-policy/busybox.json
+++ b/configurations/network-policy/expected-generated-network-policy/busybox.json
@@ -16,13 +16,15 @@
         {
             "dns": "google.com.",
             "ipBlock": "142.251.171.102/32",
-            "name": "google.com.",
+            "name": "",
+            "server": "",
             "originalIP": "142.251.171.102"
         },
         {
             "dns": "www.google.com.",
             "ipBlock": "173.194.192.99/32",
-            "name": "www.google.com.",
+            "name": "",
+            "server": "",
             "originalIP": "173.194.192.99"
         }
     ],

--- a/configurations/network-policy/expected-generated-network-policy/busybox.json
+++ b/configurations/network-policy/expected-generated-network-policy/busybox.json
@@ -1,0 +1,111 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "GeneratedNetworkPolicy",
+    "metadata": {
+        "creationTimestamp": "2023-12-03T16:33:18Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "busybox-deployment"
+        },
+        "name": "deployment-busybox-deployment",
+        "namespace": "systest-ns-7vi4"
+    },
+    "policyRef": [
+        {
+            "dns": "google.com.",
+            "ipBlock": "142.251.171.102/32",
+            "name": "google.com.",
+            "originalIP": "142.251.171.102"
+        },
+        {
+            "dns": "www.google.com.",
+            "ipBlock": "173.194.192.99/32",
+            "name": "www.google.com.",
+            "originalIP": "173.194.192.99"
+        }
+    ],
+    "spec": {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "annotations": {
+                "generated-by": "kubescape"
+            },
+            "creationTimestamp": null,
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "busybox-deployment"
+            },
+            "name": "deployment-busybox-deployment",
+            "namespace": "systest-ns-7vi4"
+        },
+        "spec": {
+            "egress": [
+                {
+                    "ports": [
+                        {
+                            "port": 80,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "ipBlock": {
+                                "cidr": "142.251.171.102/32"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ports": [
+                        {
+                            "port": 80,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "ipBlock": {
+                                "cidr": "173.194.192.99/32"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ports": [
+                        {
+                            "port": 53,
+                            "protocol": "UDP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "kubernetes.io/metadata.name": "kube-system"
+                                }
+                            },
+                            "podSelector": {
+                                "matchLabels": {
+                                    "k8s-app": "kube-dns"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "podSelector": {
+                "matchLabels": {
+                    "app": "busybox"
+                }
+            },
+            "policyTypes": [
+                "Egress"
+            ]
+        }
+    }
+}

--- a/configurations/network-policy/expected-generated-network-policy/deployment-mariadb-basic.json
+++ b/configurations/network-policy/expected-generated-network-policy/deployment-mariadb-basic.json
@@ -1,0 +1,63 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "GeneratedNetworkPolicy",
+    "metadata": {
+        "creationTimestamp": "2023-12-03T09:10:06Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "mariadb"
+        },
+        "name": "deployment-mariadb",
+        "namespace": "systest-ns-uzhe"
+    },
+    "policyRef": [],
+    "spec": {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "annotations": {
+                "generated-by": "kubescape"
+            },
+            "creationTimestamp": null,
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "mariadb"
+            },
+            "name": "deployment-mariadb",
+            "namespace": "systest-ns-uzhe"
+        },
+        "spec": {
+            "ingress": [
+                {
+                    "from": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {
+                                    "app": "wikijs"
+                                }
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "port": 3306,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ],
+            "podSelector": {
+                "matchLabels": {
+                    "app": "mariadb"
+                }
+            },
+            "policyTypes": [
+                "Ingress"
+            ]
+        }
+    }
+}

--- a/configurations/network-policy/expected-generated-network-policy/deployment-mariadb.json
+++ b/configurations/network-policy/expected-generated-network-policy/deployment-mariadb.json
@@ -1,0 +1,63 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "GeneratedNetworkPolicy",
+    "metadata": {
+        "creationTimestamp": "2023-11-30T09:41:41Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "mariadb"
+        },
+        "name": "deployment-mariadb",
+        "namespace": "systest-ns-ggjg"
+    },
+    "policyRef": [],
+    "spec": {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "annotations": {
+                "generated-by": "kubescape"
+            },
+            "creationTimestamp": null,
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "mariadb"
+            },
+            "name": "deployment-mariadb",
+            "namespace": "systest-ns-ggjg"
+        },
+        "spec": {
+            "ingress": [
+                {
+                    "from": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {
+                                    "app": "wikijs"
+                                }
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "port": 3306,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ],
+            "podSelector": {
+                "matchLabels": {
+                    "app": "mariadb"
+                }
+            },
+            "policyTypes": [
+                "Ingress"
+            ]
+        }
+    }
+}

--- a/configurations/network-policy/expected-generated-network-policy/deployment-nginx-basic.json
+++ b/configurations/network-policy/expected-generated-network-policy/deployment-nginx-basic.json
@@ -1,0 +1,68 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "GeneratedNetworkPolicy",
+    "metadata": {
+        "creationTimestamp": "2023-12-03T09:08:50Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "nginx"
+        },
+        "name": "deployment-nginx",
+        "namespace": "systest-ns-uzhe"
+    },
+    "policyRef": [],
+    "spec": {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "annotations": {
+                "generated-by": "kubescape"
+            },
+            "creationTimestamp": null,
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "nginx"
+            },
+            "name": "deployment-nginx",
+            "namespace": "systest-ns-uzhe"
+        },
+        "spec": {
+            "egress": [
+                {
+                    "ports": [
+                        {
+                            "port": 53,
+                            "protocol": "UDP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "kubernetes.io/metadata.name": "kube-system"
+                                }
+                            },
+                            "podSelector": {
+                                "matchLabels": {
+                                    "k8s-app": "kube-dns"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "podSelector": {
+                "matchLabels": {
+                    "app": "nginx"
+                }
+            },
+            "policyTypes": [
+                "Egress"
+            ]
+        }
+    }
+}

--- a/configurations/network-policy/expected-generated-network-policy/deployment-nginx.json
+++ b/configurations/network-policy/expected-generated-network-policy/deployment-nginx.json
@@ -1,0 +1,68 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "GeneratedNetworkPolicy",
+    "metadata": {
+        "creationTimestamp": "2023-11-30T09:41:27Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "nginx"
+        },
+        "name": "deployment-nginx",
+        "namespace": "systest-ns-ggjg"
+    },
+    "policyRef": [],
+    "spec": {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "annotations": {
+                "generated-by": "kubescape"
+            },
+            "creationTimestamp": null,
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "nginx"
+            },
+            "name": "deployment-nginx",
+            "namespace": "systest-ns-ggjg"
+        },
+        "spec": {
+            "egress": [
+                {
+                    "ports": [
+                        {
+                            "port": 53,
+                            "protocol": "UDP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "kubernetes.io/metadata.name": "kube-system"
+                                }
+                            },
+                            "podSelector": {
+                                "matchLabels": {
+                                    "k8s-app": "kube-dns"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "podSelector": {
+                "matchLabels": {
+                    "app": "nginx"
+                }
+            },
+            "policyTypes": [
+                "Egress"
+            ]
+        }
+    }
+}

--- a/configurations/network-policy/expected-generated-network-policy/deployment-wikijs-basic.json
+++ b/configurations/network-policy/expected-generated-network-policy/deployment-wikijs-basic.json
@@ -1,0 +1,85 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "GeneratedNetworkPolicy",
+    "metadata": {
+        "creationTimestamp": "2023-12-03T09:15:52Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "wikijs"
+        },
+        "name": "deployment-wikijs",
+        "namespace": "systest-ns-uzhe"
+    },
+    "policyRef": [],
+    "spec": {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "annotations": {
+                "generated-by": "kubescape"
+            },
+            "creationTimestamp": null,
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "wikijs"
+            },
+            "name": "deployment-wikijs",
+            "namespace": "systest-ns-uzhe"
+        },
+        "spec": {
+            "egress": [
+                {
+                    "ports": [
+                        {
+                            "port": 53,
+                            "protocol": "UDP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "kubernetes.io/metadata.name": "kube-system"
+                                }
+                            },
+                            "podSelector": {
+                                "matchLabels": {
+                                    "k8s-app": "kube-dns"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ports": [
+                        {
+                            "port": 3306,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {
+                                    "app": "mariadb"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "podSelector": {
+                "matchLabels": {
+                    "app": "wikijs"
+                }
+            },
+            "policyTypes": [
+                "Egress"
+            ]
+        }
+    }
+}

--- a/configurations/network-policy/expected-generated-network-policy/deployment-wikijs.json
+++ b/configurations/network-policy/expected-generated-network-policy/deployment-wikijs.json
@@ -1,0 +1,128 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "GeneratedNetworkPolicy",
+    "metadata": {
+        "creationTimestamp": "2023-11-30T09:41:13Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "wikijs"
+        },
+        "name": "deployment-wikijs",
+        "namespace": "systest-ns-ggjg"
+    },
+    "policyRef": [
+        {
+            "dns": "google.com.",
+            "ipBlock": "74.125.201.138/32",
+            "name": "google.com.",
+            "originalIP": "74.125.201.138"
+        },
+        {
+            "dns": "wikipedia.org.",
+            "ipBlock": "208.80.154.224/32",
+            "name": "wikipedia.org.",
+            "originalIP": "208.80.154.224"
+        }
+    ],
+    "spec": {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "annotations": {
+                "generated-by": "kubescape"
+            },
+            "creationTimestamp": null,
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "wikijs"
+            },
+            "name": "deployment-wikijs",
+            "namespace": "systest-ns-ggjg"
+        },
+        "spec": {
+            "egress": [
+                {
+                    "ports": [
+                        {
+                            "port": 443,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "ipBlock": {
+                                "cidr": "74.125.201.138/32"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ports": [
+                        {
+                            "port": 443,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "ipBlock": {
+                                "cidr": "208.80.154.224/32"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ports": [
+                        {
+                            "port": 53,
+                            "protocol": "UDP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "kubernetes.io/metadata.name": "kube-system"
+                                }
+                            },
+                            "podSelector": {
+                                "matchLabels": {
+                                    "k8s-app": "kube-dns"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ports": [
+                        {
+                            "port": 3306,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "to": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {
+                                    "app": "mariadb"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "podSelector": {
+                "matchLabels": {
+                    "app": "wikijs"
+                }
+            },
+            "policyTypes": [
+                "Egress"
+            ]
+        }
+    }
+}

--- a/configurations/network-policy/expected-generated-network-policy/deployment-wikijs.json
+++ b/configurations/network-policy/expected-generated-network-policy/deployment-wikijs.json
@@ -16,13 +16,15 @@
         {
             "dns": "google.com.",
             "ipBlock": "74.125.201.138/32",
-            "name": "google.com.",
+            "name": "",
+            "server": "",
             "originalIP": "74.125.201.138"
         },
         {
             "dns": "wikipedia.org.",
             "ipBlock": "208.80.154.224/32",
-            "name": "wikipedia.org.",
+            "name": "",
+            "server": "",
             "originalIP": "208.80.154.224"
         }
     ],

--- a/configurations/network-policy/expected-network-neighbors/busybox-known-server.json
+++ b/configurations/network-policy/expected-network-neighbors/busybox-known-server.json
@@ -1,0 +1,81 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "NetworkNeighbors",
+    "metadata": {
+        "annotations": {
+            "kubescape.io/status": "complete"
+        },
+        "creationTimestamp": "2023-12-11T11:02:21Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "busybox-deployment"
+        },
+        "name": "deployment-busybox-deployment",
+        "namespace": "systest-ns-d3qk",
+        "resourceVersion": "1",
+        "uid": "ac1da60e-d171-4c72-a070-882744d16a9c"
+    },
+    "spec": {
+        "egress": [
+            {
+                "dns": "",
+                "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",
+                "ipAddress": "",
+                "namespaceSelector": {
+                    "matchLabels": {
+                        "kubernetes.io/metadata.name": "kube-system"
+                    }
+                },
+                "podSelector": {
+                    "matchLabels": {
+                        "k8s-app": "kube-dns"
+                    }
+                },
+                "ports": [
+                    {
+                        "name": "UDP-53",
+                        "port": 53,
+                        "protocol": "UDP"
+                    }
+                ],
+                "type": "internal"
+            },
+            {
+                "dns": "www.google.com.",
+                "identifier": "a63c2f7904d77cfedc655bf8c629d0bcb638a949bd7ef94ae5825a7a397b1b60",
+                "ipAddress": "64.233.183.104",
+                "namespaceSelector": null,
+                "podSelector": null,
+                "ports": [
+                    {
+                        "name": "TCP-80",
+                        "port": 80,
+                        "protocol": "TCP"
+                    }
+                ],
+                "type": "external"
+            },
+            {
+                "dns": "",
+                "identifier": "9a1817356173a94001deda15a1a8c56bb9969454691f48661cbda6ce7f662bd4",
+                "ipAddress": "142.250.1.104",
+                "namespaceSelector": null,
+                "podSelector": null,
+                "ports": [
+                    {
+                        "name": "TCP-80",
+                        "port": 80,
+                        "protocol": "TCP"
+                    }
+                ],
+                "type": "external"
+            }
+        ],
+        "ingress": [],
+        "matchLabels": {
+            "app": "busybox"
+        }
+    }
+}

--- a/configurations/network-policy/expected-network-neighbors/busybox.json
+++ b/configurations/network-policy/expected-network-neighbors/busybox.json
@@ -1,0 +1,81 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "NetworkNeighbors",
+    "metadata": {
+        "annotations": {
+            "kubescape.io/status": "complete"
+        },
+        "creationTimestamp": "2023-12-03T16:29:26Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "busybox-deployment"
+        },
+        "name": "deployment-busybox-deployment",
+        "namespace": "systest-ns-7vi4",
+        "resourceVersion": "1",
+        "uid": "ed5fe43e-b0be-47a7-8ed7-7aef1a4c800c"
+    },
+    "spec": {
+        "egress": [
+            {
+                "dns": "google.com.",
+                "identifier": "7b011f04f8d2be91b53013aaabe7d07fda9d176a785bfbfa3fd9b1db0a630d03",
+                "ipAddress": "142.251.171.102",
+                "namespaceSelector": null,
+                "podSelector": null,
+                "ports": [
+                    {
+                        "name": "TCP-80",
+                        "port": 80,
+                        "protocol": "TCP"
+                    }
+                ],
+                "type": "external"
+            },
+            {
+                "dns": "www.google.com.",
+                "identifier": "c97fbaf27a4fc1a3da0bb4b0dfd4a24fd7f84f9210889669f297e20f6e7f67b2",
+                "ipAddress": "173.194.192.99",
+                "namespaceSelector": null,
+                "podSelector": null,
+                "ports": [
+                    {
+                        "name": "TCP-80",
+                        "port": 80,
+                        "protocol": "TCP"
+                    }
+                ],
+                "type": "external"
+            },
+            {
+                "dns": "",
+                "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",
+                "ipAddress": "",
+                "namespaceSelector": {
+                    "matchLabels": {
+                        "kubernetes.io/metadata.name": "kube-system"
+                    }
+                },
+                "podSelector": {
+                    "matchLabels": {
+                        "k8s-app": "kube-dns"
+                    }
+                },
+                "ports": [
+                    {
+                        "name": "UDP-53",
+                        "port": 53,
+                        "protocol": "UDP"
+                    }
+                ],
+                "type": "internal"
+            }
+        ],
+        "ingress": [],
+        "matchLabels": {
+            "app": "busybox"
+        }
+    }
+}

--- a/configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json
@@ -1,0 +1,47 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "NetworkNeighbors",
+    "metadata": {
+        "annotations": {
+            "kubescape.io/status": "complete"
+        },
+        "creationTimestamp": "2023-12-03T09:04:43Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "mariadb"
+        },
+        "name": "deployment-mariadb",
+        "namespace": "systest-ns-uzhe",
+        "resourceVersion": "1",
+        "uid": "7924387a-a1c1-40ee-b6c9-72b19543ed72"
+    },
+    "spec": {
+        "egress": [],
+        "ingress": [
+            {
+                "dns": "",
+                "identifier": "ee5c5b2f07834fa64174c3d2ad0505366e4b26777174906b91e83dcd163f8ec2",
+                "ipAddress": "",
+                "namespaceSelector": null,
+                "podSelector": {
+                    "matchLabels": {
+                        "app": "wikijs"
+                    }
+                },
+                "ports": [
+                    {
+                        "name": "TCP-3306",
+                        "port": 3306,
+                        "protocol": "TCP"
+                    }
+                ],
+                "type": "internal"
+            }
+        ],
+        "matchLabels": {
+            "app": "mariadb"
+        }
+    }
+}

--- a/configurations/network-policy/expected-network-neighbors/deployment-mariadb.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-mariadb.json
@@ -1,0 +1,47 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "NetworkNeighbors",
+    "metadata": {
+        "annotations": {
+            "kubescape.io/status": "complete"
+        },
+        "creationTimestamp": "2023-11-29T13:10:57Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "mariadb"
+        },
+        "name": "deployment-mariadb",
+        "namespace": "systest-ns-xn23",
+        "resourceVersion": "1",
+        "uid": "def106b9-b22a-4b56-9946-6511df424a6b"
+    },
+    "spec": {
+        "egress": [],
+        "ingress": [
+            {
+                "dns": "",
+                "identifier": "ee5c5b2f07834fa64174c3d2ad0505366e4b26777174906b91e83dcd163f8ec2",
+                "ipAddress": "",
+                "namespaceSelector": null,
+                "podSelector": {
+                    "matchLabels": {
+                        "app": "wikijs"
+                    }
+                },
+                "ports": [
+                    {
+                        "name": "TCP-3306",
+                        "port": 3306,
+                        "protocol": "TCP"
+                    }
+                ],
+                "type": "internal"
+            }
+        ],
+        "matchLabels": {
+            "app": "mariadb"
+        }
+    }
+}

--- a/configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json
@@ -1,0 +1,51 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "NetworkNeighbors",
+    "metadata": {
+        "annotations": {
+            "kubescape.io/status": "complete"
+        },
+        "creationTimestamp": "2023-12-03T09:04:43Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "nginx"
+        },
+        "name": "deployment-nginx",
+        "namespace": "systest-ns-uzhe",
+        "resourceVersion": "1",
+        "uid": "e05a19fe-bff7-4833-a488-a3eba2570d7e"
+    },
+    "spec": {
+        "egress": [
+            {
+                "dns": "",
+                "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",
+                "ipAddress": "",
+                "namespaceSelector": {
+                    "matchLabels": {
+                        "kubernetes.io/metadata.name": "kube-system"
+                    }
+                },
+                "podSelector": {
+                    "matchLabels": {
+                        "k8s-app": "kube-dns"
+                    }
+                },
+                "ports": [
+                    {
+                        "name": "UDP-53",
+                        "port": 53,
+                        "protocol": "UDP"
+                    }
+                ],
+                "type": "internal"
+            }
+        ],
+        "ingress": [],
+        "matchLabels": {
+            "app": "nginx"
+        }
+    }
+}

--- a/configurations/network-policy/expected-network-neighbors/deployment-nginx.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-nginx.json
@@ -1,0 +1,51 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "NetworkNeighbors",
+    "metadata": {
+        "annotations": {
+            "kubescape.io/status": "complete"
+        },
+        "creationTimestamp": "2023-11-29T13:10:57Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "nginx"
+        },
+        "name": "deployment-nginx",
+        "namespace": "systest-ns-xn23",
+        "resourceVersion": "1",
+        "uid": "38cbc619-81c4-4bf8-86f8-4224ba0caf7c"
+    },
+    "spec": {
+        "egress": [
+            {
+                "dns": "",
+                "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",
+                "ipAddress": "",
+                "namespaceSelector": {
+                    "matchLabels": {
+                        "kubernetes.io/metadata.name": "kube-system"
+                    }
+                },
+                "podSelector": {
+                    "matchLabels": {
+                        "k8s-app": "kube-dns"
+                    }
+                },
+                "ports": [
+                    {
+                        "name": "UDP-53",
+                        "port": 53,
+                        "protocol": "UDP"
+                    }
+                ],
+                "type": "internal"
+            }
+        ],
+        "ingress": [],
+        "matchLabels": {
+            "app": "nginx"
+        }
+    }
+}

--- a/configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
@@ -1,0 +1,70 @@
+{
+    "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+    "kind": "NetworkNeighbors",
+    "metadata": {
+        "annotations": {
+            "kubescape.io/status": "complete"
+        },
+        "creationTimestamp": "2023-12-03T09:04:44Z",
+        "labels": {
+            "kubescape.io/workload-api-group": "apps",
+            "kubescape.io/workload-api-version": "v1",
+            "kubescape.io/workload-kind": "deployment",
+            "kubescape.io/workload-name": "wikijs"
+        },
+        "name": "deployment-wikijs",
+        "namespace": "systest-ns-uzhe",
+        "resourceVersion": "1",
+        "uid": "65b357ac-3589-4608-9869-016e6a00ccd7"
+    },
+    "spec": {
+        "egress": [
+            {
+                "dns": "",
+                "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",
+                "ipAddress": "",
+                "namespaceSelector": {
+                    "matchLabels": {
+                        "kubernetes.io/metadata.name": "kube-system"
+                    }
+                },
+                "podSelector": {
+                    "matchLabels": {
+                        "k8s-app": "kube-dns"
+                    }
+                },
+                "ports": [
+                    {
+                        "name": "UDP-53",
+                        "port": 53,
+                        "protocol": "UDP"
+                    }
+                ],
+                "type": "internal"
+            },
+            {
+                "dns": "",
+                "identifier": "9230d773194d84ea09e198e98b8aaa1dd71fd6f406314796f234240bb5111425",
+                "ipAddress": "",
+                "namespaceSelector": null,
+                "podSelector": {
+                    "matchLabels": {
+                        "app": "mariadb"
+                    }
+                },
+                "ports": [
+                    {
+                        "name": "TCP-3306",
+                        "port": 3306,
+                        "protocol": "TCP"
+                    }
+                ],
+                "type": "internal"
+            }
+        ],
+        "ingress": [],
+        "matchLabels": {
+            "app": "wikijs"
+        }
+    }
+}

--- a/configurations/network-policy/expected-network-neighbors/deployment-wikijs.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-wikijs.json
@@ -1,0 +1,100 @@
+    {
+        "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+        "kind": "NetworkNeighbors",
+        "metadata": {
+            "annotations": {
+                "kubescape.io/status": "complete"
+            },
+            "creationTimestamp": "2023-11-29T13:10:58Z",
+            "labels": {
+                "kubescape.io/workload-api-group": "apps",
+                "kubescape.io/workload-api-version": "v1",
+                "kubescape.io/workload-kind": "deployment",
+                "kubescape.io/workload-name": "wikijs"
+            },
+            "name": "deployment-wikijs",
+            "namespace": "systest-ns-xn23",
+            "resourceVersion": "1",
+            "uid": "2536fe68-fa9d-495c-915e-2c33c6a02c97"
+        },
+        "spec": {
+            "egress": [
+                {
+                    "dns": "",
+                    "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",
+                    "ipAddress": "",
+                    "namespaceSelector": {
+                        "matchLabels": {
+                            "kubernetes.io/metadata.name": "kube-system"
+                        }
+                    },
+                    "podSelector": {
+                        "matchLabels": {
+                            "k8s-app": "kube-dns"
+                        }
+                    },
+                    "ports": [
+                        {
+                            "name": "UDP-53",
+                            "port": 53,
+                            "protocol": "UDP"
+                        }
+                    ],
+                    "type": "internal"
+                },
+                {
+                    "dns": "",
+                    "identifier": "9230d773194d84ea09e198e98b8aaa1dd71fd6f406314796f234240bb5111425",
+                    "ipAddress": "",
+                    "namespaceSelector": null,
+                    "podSelector": {
+                        "matchLabels": {
+                            "app": "mariadb"
+                        }
+                    },
+                    "ports": [
+                        {
+                            "name": "TCP-3306",
+                            "port": 3306,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "type": "internal"
+                },
+                {
+                    "dns": "google.com.",
+                    "identifier": "4b9e04df98fcd52293e6fc9f055e98eaae731a100fa455f9aaae05efaad36a59",
+                    "ipAddress": "209.85.145.139",
+                    "namespaceSelector": null,
+                    "podSelector": null,
+                    "ports": [
+                        {
+                            "name": "TCP-443",
+                            "port": 443,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "type": "external"
+                },
+                {
+                    "dns": "wikipedia.org.",
+                    "identifier": "379087859840bc8e8b758ec29415606771afca4af17ff3c8552ff72adc07e86c",
+                    "ipAddress": "208.80.154.224",
+                    "namespaceSelector": null,
+                    "podSelector": null,
+                    "ports": [
+                        {
+                            "name": "TCP-443",
+                            "port": 443,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "type": "external"
+                }
+            ],
+            "ingress": [],
+            "matchLabels": {
+                "app": "wikijs"
+            }
+        }
+    }

--- a/configurations/system/tests.py
+++ b/configurations/system/tests.py
@@ -1,3 +1,4 @@
+from configurations.system.tests_cases.network_policy_tests import NetworkPolicyTests
 from systest_utils import TestUtil
 
 from .tests_cases import KubescapeTests, KSMicroserviceTests
@@ -18,6 +19,7 @@ def all_tests_names():
     tests.extend(TestUtil.get_class_methods(KsVulnerabilityScanningTests))
     tests.extend(TestUtil.get_class_methods(PaymentTests))
     tests.extend(TestUtil.get_class_methods(RelevantVulnerabilityScanningTests))
+    tests.extend(TestUtil.get_class_methods(NetworkPolicyTests))
     tests.extend(TestUtil.get_class_methods(NotificationSTests))
     return tests
 
@@ -36,6 +38,8 @@ def get_test(test_name):
         return PaymentTests().__getattribute__(test_name)()
     if test_name in TestUtil.get_class_methods(RelevantVulnerabilityScanningTests):
         return RelevantVulnerabilityScanningTests().__getattribute__(test_name)()
+    if test_name in TestUtil.get_class_methods(NetworkPolicyTests):
+        return NetworkPolicyTests().__getattribute__(test_name)()
     if test_name in TestUtil.get_class_methods(NotificationSTests):
         return NotificationSTests().__getattribute__(test_name)()
 

--- a/configurations/system/tests_cases/network_policy_tests.py
+++ b/configurations/system/tests_cases/network_policy_tests.py
@@ -94,3 +94,20 @@ class NetworkPolicyTests(object):
             ],
             helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED, statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
         )
+
+
+    @staticmethod
+    def network_policy_known_servers():
+        from tests_scripts.helm.network_policy import NetworkPolicyKnownServers
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "busybox"),
+            knownservers = join(statics.DEFAULT_KNOWN_SERVERS_PATH, "known-server.json"),
+            test_obj=NetworkPolicyKnownServers,
+            expected_network_neighbors = ["configurations/network-policy/expected-network-neighbors/busybox-known-server.json",
+            ],
+            expected_generated_network_policies = [
+                "configurations/network-policy/expected-generated-network-policy/busybox-known-server.json",
+            ],
+            helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED, statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+        )

--- a/configurations/system/tests_cases/network_policy_tests.py
+++ b/configurations/system/tests_cases/network_policy_tests.py
@@ -57,3 +57,40 @@ class NetworkPolicyTests(object):
                                                  ],
             helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED, statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
         )
+
+    @staticmethod
+    def network_policy_pod_restarted():
+        from tests_scripts.helm.network_policy import NetworkPolicyPodRestarted
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            services=join(statics.DEFAULT_SERVICE_PATH, "wikijs"),
+            secret="wikijs.yaml",
+            config_maps=join(statics.DEFAULT_CONFIGMAP_PATH, "wikijs"),
+            deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "wikijs"),
+            test_obj=NetworkPolicyPodRestarted,
+            expected_network_neighbors = ["configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json",
+                 "configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json",
+                "configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json", 
+            ],
+            expected_generated_network_policies = [
+                "configurations/network-policy/expected-generated-network-policy/deployment-wikijs-basic.json",
+                    "configurations/network-policy/expected-generated-network-policy/deployment-mariadb-basic.json",
+                    "configurations/network-policy/expected-generated-network-policy/deployment-nginx-basic.json",
+            ],
+            helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED, statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+        )
+
+    @staticmethod
+    def network_policy_multiple_replicas():
+        from tests_scripts.helm.network_policy import NetworkPolicyMultipleReplicas
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "busybox"),
+            test_obj=NetworkPolicyMultipleReplicas,
+            expected_network_neighbors = ["configurations/network-policy/expected-network-neighbors/busybox.json",
+            ],
+            expected_generated_network_policies = [
+                "configurations/network-policy/expected-generated-network-policy/busybox.json",
+            ],
+            helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED, statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+        )

--- a/configurations/system/tests_cases/network_policy_tests.py
+++ b/configurations/system/tests_cases/network_policy_tests.py
@@ -1,0 +1,59 @@
+import inspect
+
+from systest_utils import statics
+from .structures import TestConfiguration
+from os.path import join
+
+class NetworkPolicyTests(object):
+
+    @staticmethod
+    def network_policy():
+        from tests_scripts.helm.network_policy import NetworkPolicy
+
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            services=join(statics.DEFAULT_SERVICE_PATH, "wikijs"),
+            secret="wikijs.yaml",
+            config_maps=join(statics.DEFAULT_CONFIGMAP_PATH, "wikijs"),
+            deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "wikijs"),
+            test_obj=NetworkPolicy,
+            expected_network_neighbors=["configurations/network-policy/expected-network-neighbors/deployment-wikijs.json",
+                 "configurations/network-policy/expected-network-neighbors/deployment-mariadb.json",
+                "configurations/network-policy/expected-network-neighbors/deployment-nginx.json", 
+            ],
+            expected_generated_network_policies=["configurations/network-policy/expected-generated-network-policy/deployment-wikijs.json",
+                    "configurations/network-policy/expected-generated-network-policy/deployment-mariadb.json",
+                    "configurations/network-policy/expected-generated-network-policy/deployment-nginx.json",
+                                                 ],
+            helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED, statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+        )
+    
+    @staticmethod
+    def network_policy_data_appended():
+        from tests_scripts.helm.network_policy import NetworkPolicyDataAppended
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            services=join(statics.DEFAULT_SERVICE_PATH, "wikijs"),
+            secret="wikijs.yaml",
+            config_maps=join(statics.DEFAULT_CONFIGMAP_PATH, "wikijs"),
+            deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "wikijs"),
+            test_obj=NetworkPolicyDataAppended,
+            expected_network_neighbors = ["configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json",
+                 "configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json",
+                "configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json", 
+            ],
+            expected_generated_network_policies = [
+                "configurations/network-policy/expected-generated-network-policy/deployment-wikijs-basic.json",
+                    "configurations/network-policy/expected-generated-network-policy/deployment-mariadb-basic.json",
+                    "configurations/network-policy/expected-generated-network-policy/deployment-nginx-basic.json",
+            ],
+            expected_updated_network_neighbors=["configurations/network-policy/expected-network-neighbors/deployment-wikijs.json",
+                 "configurations/network-policy/expected-network-neighbors/deployment-mariadb.json",
+                "configurations/network-policy/expected-network-neighbors/deployment-nginx.json", 
+            ],
+            expected_updated_generated_network_policies=["configurations/network-policy/expected-generated-network-policy/deployment-wikijs.json",
+                    "configurations/network-policy/expected-generated-network-policy/deployment-mariadb.json",
+                    "configurations/network-policy/expected-generated-network-policy/deployment-nginx.json",
+                                                 ],
+            helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED, statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+        )

--- a/jenkins_files/Jenkinsfile_helm_chart.groovy
+++ b/jenkins_files/Jenkinsfile_helm_chart.groovy
@@ -27,7 +27,8 @@ def tests = [
             "network_policy":                                                                      ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
             "network_policy_data_appended":                                                          ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
             "network_policy_pod_restarted":                                                         ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
-            "network_policy_multiple_replicas":                                                    ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"]
+            "network_policy_multiple_replicas":                                                    ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
+            "network_policy_known_servers":                                                    ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"]
              ]
 
 def parallelStagesMap = tests.collectEntries {

--- a/jenkins_files/Jenkinsfile_helm_chart.groovy
+++ b/jenkins_files/Jenkinsfile_helm_chart.groovy
@@ -23,7 +23,11 @@ def tests = [
              "vulnerability_scanning_triggering_with_cron_job":                           ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "registry_scanning_triggering_with_cron_job":                               ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
              "vulnerability_scanning_test_public_registry_connectivity_by_backend" :                       ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
-             "vulnerability_scanning_test_public_registry_connectivity_excluded_by_backend":             ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"]
+             "vulnerability_scanning_test_public_registry_connectivity_excluded_by_backend":             ["CA-AWS-DEV-JENKINS-EC2-FLEET-X-LARGE",  "k8s"],
+            "network_policy":                                                                      ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
+            "network_policy_data_appended":                                                          ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
+            "network_policy_pod_restarted":                                                         ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
+            "network_policy_multiple_replicas":                                                    ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"]
              ]
 
 def parallelStagesMap = tests.collectEntries {

--- a/jenkins_files/Jenkinsfile_relevancy.groovy
+++ b/jenkins_files/Jenkinsfile_relevancy.groovy
@@ -18,7 +18,8 @@ def tests = ["vulnerability_scanning":                                          
             "relevancy_enabled_stop_sniffing":                                           ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
             "relevant_data_is_appended":                                                  ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
             "relevancy_extra_large_image":                                               ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
-            "relevancy_large_image":                                                    ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"]
+            "relevancy_large_image":                                                    ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
+            "network_policy":                                                          ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"]
              
              ]
 

--- a/jenkins_files/Jenkinsfile_relevancy.groovy
+++ b/jenkins_files/Jenkinsfile_relevancy.groovy
@@ -18,8 +18,7 @@ def tests = ["vulnerability_scanning":                                          
             "relevancy_enabled_stop_sniffing":                                           ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
             "relevant_data_is_appended":                                                  ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
             "relevancy_extra_large_image":                                               ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
-            "relevancy_large_image":                                                    ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"],
-            "network_policy":                                                          ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"]
+            "relevancy_large_image":                                                    ["CA-AWS-DEV-JENKINS-EC2-FLEET-2X-LARGE-RELEVANCY",  "k8s"]
              
              ]
 

--- a/systest_utils/statics.py
+++ b/systest_utils/statics.py
@@ -201,6 +201,11 @@ STORAGE_AGGREGATED_API_GROUP = "spdx.softwarecomposition.kubescape.io"
 STORAGE_AGGREGATED_API_VERSION = "v1beta1"
 STORAGE_AGGREGATED_API_NAMESPACE = "kubescape"
 
+GENERATED_NETWORK_POLICY_PLURAL = "generatednetworkpolicies"
+
+NETWORK_NEIGHBOR_PLURAL = "networkneighborses"
+NETWORK_NEIGHBOR_KIND = "NetworkNeighbors"
+
 STORAGE_CVE_LABEL = "kubescape.io/context"
 STORAGE_FILTERED_CVE_LABEL_VALUE = "filtered"
 
@@ -213,6 +218,9 @@ RELEVANCY_WLID_ANNOTATION = "kubescape.io/wlid"
 
 
 # relevancy feature
+HELM_NETWORK_POLICY_FEATURE = "capabilities.networkPolicyService"
+HELM_NODE_AGENT_LEARNING_PERIOD = "nodeAgent.config.learningPeriod"
+HELM_NODE_AGENT_UPDATE_PERIOD = "nodeAgent.config.updatePeriod"
 HELM_RELEVANCY_FEATURE = "capabilities.relevancy"
 HELM_RELEVANCY_FEATURE_ENABLED = "enable"
 HELM_RELEVANCY_FEATURE_DISABLED = "disable"

--- a/systest_utils/statics.py
+++ b/systest_utils/statics.py
@@ -31,6 +31,7 @@ DEFAULT_GRYPE_BINARIES_PATH = os.path.abspath('grype-versioning/grype-binaries')
 # k8s paths
 DEFAULT_K8S_PATHS = os.path.abspath(os.path.join('configurations', 'k8s_workloads'))
 DEFAULT_DEPLOYMENT_PATH = os.path.join(DEFAULT_K8S_PATHS, 'deployments')
+DEFAULT_KNOWN_SERVERS_PATH = os.path.join(DEFAULT_K8S_PATHS, 'known-servers')
 DEFAULT_SERVICE_PATH = os.path.join(DEFAULT_K8S_PATHS, 'services')
 DEFAULT_SERVICE_ACCOUNT_PATH = os.path.join(DEFAULT_K8S_PATHS, 'service-accounts')
 DEFAULT_CLUSTER_ROLE_PATH = os.path.join(DEFAULT_K8S_PATHS, 'rbac')
@@ -201,10 +202,10 @@ STORAGE_AGGREGATED_API_GROUP = "spdx.softwarecomposition.kubescape.io"
 STORAGE_AGGREGATED_API_VERSION = "v1beta1"
 STORAGE_AGGREGATED_API_NAMESPACE = "kubescape"
 
+KNOWN_SERVERS_PLURAL = "knownservers"
 GENERATED_NETWORK_POLICY_PLURAL = "generatednetworkpolicies"
 
 NETWORK_NEIGHBOR_PLURAL = "networkneighborses"
-NETWORK_NEIGHBOR_KIND = "NetworkNeighbors"
 
 STORAGE_CVE_LABEL = "kubescape.io/context"
 STORAGE_FILTERED_CVE_LABEL_VALUE = "filtered"

--- a/systest_utils/systests_utilities.py
+++ b/systest_utils/systests_utilities.py
@@ -232,6 +232,16 @@ class TestUtil(object):
                 return True
             TestUtil.sleep(wait)
         return False
+    
+    @staticmethod
+    def load_objs_from_json_files(file_paths: list):
+        objs_list = []
+        for file_path in file_paths:
+            with open(file_path) as f:
+                    obj = json.load(f)
+                    objs_list.append(obj)
+
+        return objs_list
 
     @staticmethod
     def run_command(command_args: list, timeout=60, display_stdout: bool = True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd: str="", env=None):

--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -115,9 +115,11 @@ class BaseHelm(BaseK8S):
             security_params = {"operator.triggerSecurityFramework": "false"}
             helm_kwargs.update(security_params)
 
-        helm_kwargs.update({"nodeAgent.config.learningPeriod": self.filtered_sbom_init_time, 
-                            "nodeAgent.config.updatePeriod": self.filtered_sbom_update_time,
-                            })
+        if "nodeAgent.config.learningPeriod" not in helm_kwargs:
+            helm_kwargs.update({"nodeAgent.config.learningPeriod": self.filtered_sbom_init_time})
+            
+        if "nodeAgent.config.updatePeriod" not in helm_kwargs:
+            helm_kwargs.update({"nodeAgent.config.updatePeriod": self.filtered_sbom_update_time})
         
         HelmWrapper.install_armo_helm_chart(customer=self.backend.get_customer_guid() if self.backend != None else "",
                                             access_key=self.backend.get_access_key() if self.backend != None else "",

--- a/tests_scripts/helm/base_network_policy.py
+++ b/tests_scripts/helm/base_network_policy.py
@@ -1,0 +1,288 @@
+import time, requests, os, re, random, yaml, base64, json, hashlib
+from systest_utils import statics, Logger, TestUtil
+from tests_scripts.helm.base_helm import BaseHelm
+from pkg_resources import parse_version
+from tests_scripts.kubernetes.base_k8s import BaseK8S
+from deepdiff import DeepDiff
+
+
+class BaseNetworkPolicy(BaseHelm):
+    def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
+        super(BaseNetworkPolicy, self).__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
+                                                        kubernetes_obj=kubernetes_obj)
+
+    def validate_basic_metadata(self, actual_obj, expected_obj, namespace):
+        """
+        Validate basic metadata of the object
+        param actual_obj: actual object
+        param expected_obj: expected object
+        param namespace: namespace of the object
+        """
+        assert actual_obj['apiVersion'] == expected_obj['apiVersion'], f"apiVersion is not equal, actual: {actual_obj['apiVersion']}, expected: {expected_obj['apiVersion']}"
+
+        assert actual_obj['kind'] == expected_obj['kind'], f"kind is not equal, actual: {actual_obj['kind']}, expected: {expected_obj['kind']}"
+
+
+        assert actual_obj['metadata']['name'] == expected_obj['metadata']['name'], f"name is not equal, actual: {actual_obj['metadata']['name']}, expected: {expected_obj['metadata']['name']}"
+        assert actual_obj['metadata']['namespace'] == namespace, f"namespace is not equal, actual: {actual_obj['metadata']['namespace']}, expected: {namespace}"
+
+
+        if 'annotations' in expected_obj['metadata']:
+            for key, annotation in expected_obj['metadata']['annotations'].items():
+                assert actual_obj['metadata']['annotations'][key] == annotation, f"annotation {key} is not equal, actual: {actual_obj['metadata']['annotations'][key]}, expected: {annotation}"
+
+        for key, label in expected_obj['metadata']['labels'].items():
+            assert actual_obj['metadata']['labels'][key] == label, f"label {key} is not equal, actual: {actual_obj['metadata']['labels'][key]}, expected: {label}"
+        
+    
+    def validate_expected_network_neighbors_list(self, namespace, expected_network_neighbors_list):
+        """
+        Validate expected network neighbors list. It pulls the actual network neighbors and validates each one of them
+        param namespace: namespace of the object
+        param expected_network_neighbors_list: list of expected network neighbors
+        """
+        for expected_network_neighbors in expected_network_neighbors_list:
+            actual_network_neighbors = self.get_network_neighbors(name=expected_network_neighbors['metadata']['name'] ,namespace=namespace)
+            self.validate_expected_network_neighbors(actual_network_neighbors=actual_network_neighbors, expected_network_neighbors=expected_network_neighbors, namespace=namespace)
+    
+    
+    def validate_expected_network_neighbors(self, actual_network_neighbors, expected_network_neighbors, namespace: str):
+        """
+        Validate expected network neighbors. It validates the basic metadata and then validates the network neighbors entries and the match labels
+        param actual_network_neighbors: actual network neighbors
+        param expected_network_neighbors: expected network neighbors
+        param namespace: namespace of the object
+        """
+
+        self.validate_basic_metadata(actual_obj=actual_network_neighbors, expected_obj=expected_network_neighbors, namespace=namespace)
+        
+        for key, label in expected_network_neighbors['spec']['matchLabels'].items():
+            assert actual_network_neighbors['spec']['matchLabels'][key] == label, f"label {key} is not equal, actual: {actual_network_neighbors['spec']['matchLabels'][key]}, expected: {label}"
+
+
+        expected_egress_entries = expected_network_neighbors['spec']['egress']
+        actual_egress_entries = actual_network_neighbors['spec']['egress']
+
+        self.validate_network_neighbor_entry(expected_egress_entries, actual_egress_entries)
+
+        expected_ingress_entries = expected_network_neighbors['spec']['ingress']
+        actual_ingress_entries = actual_network_neighbors['spec']['ingress']
+
+        self.validate_network_neighbor_entry(expected_entries=expected_ingress_entries, actual_entries=actual_ingress_entries)
+
+
+    def validate_network_neighbor_entry(self, expected_entries, actual_entries):
+        """
+        Validate a single network neighbor entry. 
+        param expected_entries: expected network neighbor entries
+        param actual_entries: actual network neighbor entries        
+        """
+
+        assert len(expected_entries) == len(actual_entries), f"expected_entries length is not equal to actual_entries length, actual: {len(actual_entries)}, expected: {len(expected_entries)}"
+
+        verified_entries = []
+
+        # we can't use the identifier for the entry, since IP addresses may change. Instead, we check for all fields that are not IP addresses, and verify that they are equal. If they are all equal, we count this entry as verified.
+        for expected_entry in expected_entries:
+            for  actual_entry in actual_entries:
+                    if expected_entry["dns"] != actual_entry["dns"]:
+                        continue
+                    
+                    if expected_entry["ipAddress"] != "":
+                        if actual_entry["ipAddress"] == "":
+                            continue
+                    
+                    if expected_entry["type"] != actual_entry["type"]:
+                        continue
+
+                    is_labels = True
+                    if expected_entry["namespaceSelector"] is not None:
+                        for key, label  in expected_entry["namespaceSelector"]["matchLabels"].items():
+                            if actual_entry["namespaceSelector"]["matchLabels"][key] != label:
+                                is_labels = False
+                                break
+                    
+                    if not is_labels:
+                        continue
+                    
+                    is_labels = True
+                    if expected_entry["podSelector"] is not None:
+                        for key, label  in expected_entry["podSelector"]["matchLabels"].items():
+                            if key not in actual_entry["podSelector"]["matchLabels"]:
+                                is_labels = False
+                                break
+                            if actual_entry["podSelector"]["matchLabels"][key] != label:
+                                is_labels = False
+                                break
+                    
+                    if not is_labels:
+                        continue
+
+                    verified_ports = 0
+                    for expected_port in expected_entry["ports"]:
+                        for actual_port in actual_entry["ports"]:
+                            if expected_port["name"] != actual_port["name"]:
+                                continue
+                            if expected_port["protocol"] != actual_port["protocol"]:
+                                continue
+                            if expected_port["port"] != actual_port["port"]:
+                                continue
+                            verified_ports += 1
+                            break
+
+                    if verified_ports != len(expected_entry["ports"]):
+                        continue
+
+                    verified_entries.append(expected_entry)
+                    break
+    
+        assert len(verified_entries) == len(expected_entries), f"verified_entries length is not equal to expected_entries length, actual: {verified_entries}, expected: {expected_entries}"
+
+
+    def validate_expected_generated_network_policy_list(self, namespace, expected_generated_network_policy_list):
+        """
+        Validate expected generated network policies list. It pulls the actual generated network policies and validates each one of them
+        param namespace: namespace of the object
+        param expected_generated_network_policy_list: list of expected generated network policies
+        """
+        for expected_generated_network_policy in expected_generated_network_policy_list:
+            actual_generated_network_policy = self.get_generated_network_policy(namespace=namespace, name=expected_generated_network_policy['metadata']['name'])
+            self.validate_expected_generated_network_policy(actual_network_policy=actual_generated_network_policy,expected_network_policy=expected_generated_network_policy, namespace=namespace)
+
+
+    def validate_expected_generated_network_policy(self, expected_network_policy, actual_network_policy, namespace: str):
+        """
+        Validate expected generated network policy. It validates the basic metadata and then validates the policy refs and the network policy
+        param expected_network_policy: expected generated network policy
+        param actual_network_policy: actual generated network policy
+        """
+
+        self.validate_basic_metadata( actual_obj=actual_network_policy,expected_obj= expected_network_policy, namespace= namespace)
+
+        actual_policies_refs = actual_network_policy['policyRef']
+        expected_policies_refs = expected_network_policy['policyRef']
+        self.validate_policy_refs(actual_policy_refs=actual_policies_refs, expected_policy_refs=expected_policies_refs)
+
+        actual_policy = actual_network_policy['spec']
+        expected_policy = expected_network_policy['spec']
+        self.validate_network_policy(actual_network_policy=actual_policy, expected_network_policy=expected_policy, namespace=namespace)
+
+    
+    def validate_network_policy(self, actual_network_policy, expected_network_policy, namespace: str):
+        """
+        Validate network policy. It validates the basic metadata and then validates the network policy entries
+        param actual_network_policy: actual network policy
+        param expected_network_policy: expected network policy
+        param namespace: namespace of the object
+        """
+
+        self.validate_basic_metadata(actual_obj=actual_network_policy, expected_obj=expected_network_policy, namespace=namespace)
+
+        if 'Ingress' in expected_network_policy['spec']['policyTypes']:
+            expected_network_policy_entries = expected_network_policy['spec']['ingress']
+            actual_network_policy_entries = actual_network_policy['spec']['ingress']
+            self.validate_network_policy_entry(expected_network_policy_entries=expected_network_policy_entries, actual_network_policy_entries=actual_network_policy_entries) 
+
+        if 'Egress' in expected_network_policy['spec']['policyTypes']:
+            expected_network_policy_entries = expected_network_policy['spec']['egress']
+            actual_network_policy_entries = actual_network_policy['spec']['egress']
+            self.validate_network_policy_entry(expected_network_policy_entries=expected_network_policy_entries,actual_network_policy_entries=actual_network_policy_entries)
+
+    
+    def validate_network_policy_entry(self, expected_network_policy_entries, actual_network_policy_entries):
+        """
+        Validate network policy entry. It validates the ports and then validates the to and from entries
+        param expected_network_policy_entries: expected network policy entries
+        param actual_network_policy_entries: actual network policy entries
+        """
+
+        verified_entries = 0
+
+        for expected_network_policy_entry in expected_network_policy_entries:
+            for actual_network_policy_entry in actual_network_policy_entries:
+                verified_ports = 0
+                for expected_ports in expected_network_policy_entry['ports']:
+                    for actual_ports in actual_network_policy_entry['ports']:
+                        if expected_ports['port'] == actual_ports['port']:
+                            if expected_ports['protocol'] == actual_ports['protocol']:
+                                 verified_ports += 1 
+                if verified_ports != len(expected_network_policy_entry['ports']):
+                    continue
+
+
+                if 'to' in expected_network_policy_entry:
+                    if self.verify_network_policy_entries(expected_entries=expected_network_policy_entry['to'], actual_entries=actual_network_policy_entry['to']) is False:
+                        break
+
+                if 'from'  in expected_network_policy_entry:
+                    if self.verify_network_policy_entries(expected_entries=expected_network_policy_entry['from'], actual_entries=actual_network_policy_entry['from']) is False:
+                        break
+
+                verified_entries += 1
+                break
+
+        assert verified_entries == len(expected_network_policy_entries), f"verified_entries is not equal, actual: {verified_entries}, expected: {len(expected_network_policy_entries)}"
+
+
+    def verify_network_policy_entries(self, expected_entries, actual_entries):
+        """
+        Verify entries. It verifies the ipBlock and the match labels
+        param expected_entries: expected entries
+        param actual_entries: actual entries
+        """
+
+        verified_entries = 0
+        for expected_to_from in expected_entries:
+            for actual_to_from in actual_entries:
+                if 'ipBlock' in expected_to_from:
+                    if 'ipBlock' in actual_to_from:
+                        verified_entries += 1
+                        break
+                        
+                is_labels = True
+                if "namespaceSelector" in expected_to_from:
+                    is_labels = False
+                    if "namespaceSelector" in actual_to_from:
+                        for key, label  in expected_to_from["namespaceSelector"]["matchLabels"].items():
+                            if actual_to_from["namespaceSelector"]["matchLabels"][key] == label:
+                                is_labels = True
+                                break
+                if not is_labels:
+                    continue        
+
+                is_labels = True
+                if "podSelector" in expected_to_from:
+                    is_labels = False
+                    if "podSelector"  in actual_to_from:
+                        for key, label  in expected_to_from["podSelector"]["matchLabels"].items():
+                            if actual_to_from["podSelector"]["matchLabels"][key] == label:
+                                is_labels = True
+                                break
+                if not is_labels:
+                    continue   
+                verified_entries += 1
+        return verified_entries == len(expected_entries)
+
+
+    def validate_policy_refs(self, actual_policy_refs, expected_policy_refs):
+        """
+        Validate policy refs. It validates the name and the dns of each ref
+        param actual_policy_refs: actual policy refs
+        param expected_policy_refs: expected policy refs
+        """
+
+        verified_refs = 0
+
+        for expected_policy_ref in expected_policy_refs:
+            for actual_policy_ref in actual_policy_refs:
+                if expected_policy_ref['dns'] == actual_policy_ref['dns']:
+                    assert expected_policy_ref['name'] == actual_policy_ref['name'], f"name is not equal, actual: {actual_policy_ref['name']}, expected: {expected_policy_ref['name']}"
+                    verified_refs += 1
+                    break
+
+        assert verified_refs == len(expected_policy_refs), f"verified_refs is not equal, actual: {verified_refs}, expected: {len(expected_policy_refs)}"
+    
+
+    def cleanup(self, **kwargs):
+        super().cleanup(**kwargs)
+        return statics.SUCCESS, ""

--- a/tests_scripts/helm/base_network_policy.py
+++ b/tests_scripts/helm/base_network_policy.py
@@ -97,10 +97,13 @@ class BaseNetworkPolicy(BaseHelm):
 
                     is_labels = True
                     if expected_entry["namespaceSelector"] is not None:
-                        for key, label  in expected_entry["namespaceSelector"]["matchLabels"].items():
-                            if actual_entry["namespaceSelector"]["matchLabels"][key] != label:
-                                is_labels = False
-                                break
+                        if actual_entry["namespaceSelector"] is not None:
+                            for key, label  in expected_entry["namespaceSelector"]["matchLabels"].items():
+                                if actual_entry["namespaceSelector"]["matchLabels"][key] != label:
+                                    is_labels = False
+                                    break
+                        else:
+                            is_labels = False
                     
                     if not is_labels:
                         continue
@@ -277,6 +280,7 @@ class BaseNetworkPolicy(BaseHelm):
             for actual_policy_ref in actual_policy_refs:
                 if expected_policy_ref['dns'] == actual_policy_ref['dns']:
                     assert expected_policy_ref['name'] == actual_policy_ref['name'], f"name is not equal, actual: {actual_policy_ref['name']}, expected: {expected_policy_ref['name']}"
+                    assert expected_policy_ref['server'] == actual_policy_ref['server'], f"server is not equal, actual: {actual_policy_ref['server']}, expected: {expected_policy_ref['server']}"
                     verified_refs += 1
                     break
 

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -170,7 +170,7 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         Test plan:
         1. Apply workloads
         2. Install Armo helm-chart
-        3. Generate traffic
+        3. Restart workloads
         4. Validate network neighbors
         5. Validate generated network policies
         6. TODO: Check BE APIs
@@ -223,6 +223,8 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
 
         
         #TODO: check BE APIs
+        
+        #TODO: check deletion flow
 
         Logger.logger.info('delete armo namespace')
         self.uninstall_armo_helm_chart()
@@ -307,9 +309,10 @@ class NetworkPolicyKnownServers(BaseNetworkPolicy):
         2. Apply workloads
         3. Apply Known Servers
         4. Send request from within Pod to the Known Server
-        5. Validate network policy
-        6. TODO: Check BE APIs
-        7. TODO: Check deletion flow
+        5. Validate network neighbors
+        6. Validate network policy
+        7. TODO: Check BE APIs
+        8. TODO: Check deletion flow
         """
 
         cluster, namespace = self.setup(apply_services=False)

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -17,7 +17,8 @@ class NetworkPolicy(BaseNetworkPolicy):
         4. Validate network neighbors
         5. Validate generated network policies
         6. TODO: Check BE APIs
-        7. Uninstall Armo helm-chart
+        7. TODO: Check deletion flow
+        8. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -67,6 +68,8 @@ class NetworkPolicy(BaseNetworkPolicy):
         
         #TODO: check BE APIs
 
+        #TODO: check deletion flow
+
         Logger.logger.info('delete armo namespace')
         self.uninstall_armo_helm_chart()
 
@@ -89,7 +92,8 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
         6. Check second generate network neighbors
         7. Check second generated network policies
         8. TODO: Check BE APIs
-        9. Uninstall Armo helm-chart
+        9. TODO: Check deletion flow
+        10. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -148,6 +152,8 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
 
         #TODO: check BE APIs
 
+        # TODO: check deletion flow
+
         Logger.logger.info('delete armo namespace')
         self.uninstall_armo_helm_chart()
 
@@ -168,7 +174,8 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         4. Validate network neighbors
         5. Validate generated network policies
         6. TODO: Check BE APIs
-        7. Uninstall Armo helm-chart
+        7. TODO: Check deletion flow
+        8. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -237,7 +244,8 @@ class NetworkPolicyMultipleReplicas(BaseNetworkPolicy):
         4. Validate network neighbors (data is aggregated from all pods)
         5. Validate generated network policies (data is aggregated from all pods)
         6. TODO: Check BE APIs
-        7. Uninstall Armo helm-chart
+        7. TODO: Check deletion flow
+        8. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -278,6 +286,8 @@ class NetworkPolicyMultipleReplicas(BaseNetworkPolicy):
 
         
         #TODO: check BE APIs
+
+        # TODO: check deletion flow
 
         Logger.logger.info('delete armo namespace')
         self.uninstall_armo_helm_chart()

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -1,0 +1,153 @@
+from systest_utils.systests_utilities import TestUtil
+from tests_scripts.helm.base_network_policy import BaseNetworkPolicy
+from systest_utils import statics, Logger
+
+
+class NetworkPolicy(BaseNetworkPolicy):
+    def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
+        super(NetworkPolicy, self).__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
+                                                    kubernetes_obj=kubernetes_obj)
+
+    def start(self):
+        """
+        Test plan:
+        1. Install Armo helm-chart
+        2. Apply workloads
+        3. Generate traffic
+        4. Validate network neighbors
+        5. Validate generated network policies
+        6. TODO: Check BE APIs
+        7. Uninstall Armo helm-chart
+        """
+
+        cluster, namespace = self.setup(apply_services=False)
+
+        helm_kwargs = self.test_obj.get_arg("helm_kwargs")
+        
+        Logger.logger.info('install armo helm-chart')
+        self.add_and_upgrade_armo_to_repo()
+        self.install_armo_helm_chart(helm_kwargs=helm_kwargs)
+        self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360)
+
+        Logger.logger.info('apply services')
+        self.apply_directory(path=self.test_obj[("services", None)], namespace=namespace)
+        Logger.logger.info('apply config-maps')
+        self.apply_directory(path=self.test_obj[("config_maps", None)], namespace=namespace)
+        Logger.logger.info('apply secrets')
+        self.apply_directory(path=self.test_obj[("secrets", None)], namespace=namespace)
+        Logger.logger.info('apply workloads')
+        workload_objs: list = self.apply_directory(path=self.test_obj["deployments"], namespace=namespace)
+        self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
+
+        duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
+        TestUtil.sleep(2 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+
+        pod = self.wait_for_report(report_type=self.get_pod_if_ready, namespace=namespace, name="wikijs", timeout=180)
+        pod_name = pod[0].metadata.name
+
+        Logger.logger.info(f"pod {pod_name} is ready. Triggering exec commands")
+        self.wait_for_report(timeout=180, report_type=self.run_exec_cmd, namespace=namespace, pod_name=pod_name, cmd="curl https://google.com")
+        self.wait_for_report(timeout=180, report_type=self.run_exec_cmd, namespace=namespace, pod_name=pod_name, cmd="curl https://wikipedia.org")
+        
+        update_period_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_UPDATE_PERIOD][:-1]
+        TestUtil.sleep(2 * int(update_period_in_seconds), "wait for node-agent update period", "info")
+
+        expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
+
+        Logger.logger.info("validating expected network neighbors")
+        self.validate_expected_network_neighbors_list(namespace=namespace, expected_network_neighbors_list=expected_network_neighbors_list)
+
+        expected_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_generated_network_policies"])
+
+        Logger.logger.info("validating expected generated network policies")
+        self.validate_expected_generated_network_policy_list(namespace=namespace, expected_generated_network_policy_list=expected_generated_network_policy_list)
+
+        
+        #TODO: check BE APIs
+
+        Logger.logger.info('delete armo namespace')
+        self.uninstall_armo_helm_chart()
+
+        return self.cleanup()
+
+class NetworkPolicyDataAppended(BaseNetworkPolicy):
+    def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
+        super(BaseNetworkPolicy, self).__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
+                                                    kubernetes_obj=kubernetes_obj)
+
+    def start(self):
+        """
+        Test plan:
+        1. Install Armo helm-chart
+        2. Apply workloads
+        3. Check first generate network neighbors
+        4. Check first generated network policies
+        5. Generate traffic
+        6. Check second generate network neighbors
+        7. Check second generated network policies
+        8. TODO: Check BE APIs
+        9. Uninstall Armo helm-chart
+        """
+
+        cluster, namespace = self.setup(apply_services=False)
+
+        helm_kwargs = self.test_obj.get_arg("helm_kwargs")
+        
+        Logger.logger.info('install armo helm-chart')
+        self.add_and_upgrade_armo_to_repo()
+        self.install_armo_helm_chart(helm_kwargs=helm_kwargs)
+        self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360)
+
+        Logger.logger.info('apply services')
+        self.apply_directory(path=self.test_obj[("services", None)], namespace=namespace)
+        Logger.logger.info('apply config-maps')
+        self.apply_directory(path=self.test_obj[("config_maps", None)], namespace=namespace)
+        Logger.logger.info('apply secrets')
+        self.apply_directory(path=self.test_obj[("secrets", None)], namespace=namespace)
+        Logger.logger.info('apply workloads')
+        workload_objs: list = self.apply_directory(path=self.test_obj["deployments"], namespace=namespace)
+        self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
+
+        duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
+        TestUtil.sleep(2 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+
+        expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
+
+        Logger.logger.info("validating expected network neighbors")
+        self.validate_expected_network_neighbors_list(namespace, expected_network_neighbors_list)
+
+        expected_generated_network_policy_list = TestUtil.load_objs_from_json_files(self.test_obj["expected_generated_network_policies"])
+
+        Logger.logger.info("validating expected generated network policies")
+        self.validate_expected_generated_network_policy_list(namespace, expected_generated_network_policy_list)
+
+        pod = self.wait_for_report(report_type=self.get_pod_if_ready, namespace=namespace, name="wikijs", timeout=180)
+        pod_name = pod[0].metadata.name
+
+        Logger.logger.info(f"pod {pod_name} is ready. Triggering exec commands")
+        self.wait_for_report(timeout=180, report_type=self.run_exec_cmd, namespace=namespace, pod_name=pod_name, cmd="curl https://google.com")
+        self.wait_for_report(timeout=180, report_type=self.run_exec_cmd, namespace=namespace, pod_name=pod_name, cmd="curl https://wikipedia.org")
+
+        update_period_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_UPDATE_PERIOD][:-1]
+        TestUtil.sleep(2 * int(update_period_in_seconds), "wait for node-agent update period", "info")
+
+        Logger.logger.info("validating updated expected network neighbors")
+        expected_updated_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_updated_network_neighbors"])
+        self.validate_expected_network_neighbors_list(namespace=namespace, expected_network_neighbors_list=expected_updated_network_neighbors_list)
+
+        Logger.logger.info("validating updated expected generated network policies")
+        expected_updated_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_updated_generated_network_policies"])
+        self.validate_expected_generated_network_policy_list(namespace=namespace, expected_generated_network_policy_list=expected_updated_generated_network_policy_list)
+
+        #TODO: check BE APIs
+
+        Logger.logger.info('delete armo namespace')
+        self.uninstall_armo_helm_chart()
+
+        return self.cleanup()
+
+    
+
+
+
+

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -56,11 +56,13 @@ class NetworkPolicy(BaseNetworkPolicy):
 
         Logger.logger.info("validating expected network neighbors")
         self.validate_expected_network_neighbors_list(namespace=namespace, expected_network_neighbors_list=expected_network_neighbors_list)
+        Logger.logger.info("validated expected network neighbors")
 
         expected_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_generated_network_policies"])
 
         Logger.logger.info("validating expected generated network policies")
         self.validate_expected_generated_network_policy_list(namespace=namespace, expected_generated_network_policy_list=expected_generated_network_policy_list)
+        Logger.logger.info("validated expected generated network policies")
 
         
         #TODO: check BE APIs
@@ -70,9 +72,10 @@ class NetworkPolicy(BaseNetworkPolicy):
 
         return self.cleanup()
 
+
 class NetworkPolicyDataAppended(BaseNetworkPolicy):
     def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
-        super(BaseNetworkPolicy, self).__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
+        super(NetworkPolicyDataAppended, self).__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
                                                     kubernetes_obj=kubernetes_obj)
 
     def start(self):
@@ -115,11 +118,13 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
 
         Logger.logger.info("validating expected network neighbors")
         self.validate_expected_network_neighbors_list(namespace, expected_network_neighbors_list)
+        Logger.logger.info("validated expected network neighbors")
 
         expected_generated_network_policy_list = TestUtil.load_objs_from_json_files(self.test_obj["expected_generated_network_policies"])
 
         Logger.logger.info("validating expected generated network policies")
         self.validate_expected_generated_network_policy_list(namespace, expected_generated_network_policy_list)
+        Logger.logger.info("validated expected generated network policies")
 
         pod = self.wait_for_report(report_type=self.get_pod_if_ready, namespace=namespace, name="wikijs", timeout=180)
         pod_name = pod[0].metadata.name
@@ -134,10 +139,12 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
         Logger.logger.info("validating updated expected network neighbors")
         expected_updated_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_updated_network_neighbors"])
         self.validate_expected_network_neighbors_list(namespace=namespace, expected_network_neighbors_list=expected_updated_network_neighbors_list)
+        Logger.logger.info("validated updated expected network neighbors")
 
         Logger.logger.info("validating updated expected generated network policies")
         expected_updated_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_updated_generated_network_policies"])
         self.validate_expected_generated_network_policy_list(namespace=namespace, expected_generated_network_policy_list=expected_updated_generated_network_policy_list)
+        Logger.logger.info("validated updated expected generated network policies")
 
         #TODO: check BE APIs
 
@@ -146,8 +153,133 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
 
         return self.cleanup()
 
-    
+
+class NetworkPolicyPodRestarted(BaseNetworkPolicy):
+    def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
+        super(NetworkPolicyPodRestarted, self).__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
+                                                    kubernetes_obj=kubernetes_obj)
+
+    def start(self):
+        """
+        Test plan:
+        1. Apply workloads
+        2. Install Armo helm-chart
+        3. Generate traffic
+        4. Validate network neighbors
+        5. Validate generated network policies
+        6. TODO: Check BE APIs
+        7. Uninstall Armo helm-chart
+        """
+
+        cluster, namespace = self.setup(apply_services=False)
+
+        
+        Logger.logger.info('apply services')
+        self.apply_directory(path=self.test_obj[("services", None)], namespace=namespace)
+        Logger.logger.info('apply config-maps')
+        self.apply_directory(path=self.test_obj[("config_maps", None)], namespace=namespace)
+        Logger.logger.info('apply secrets')
+        self.apply_directory(path=self.test_obj[("secrets", None)], namespace=namespace)
+        Logger.logger.info('apply workloads')
+        workload_objs: list = self.apply_directory(path=self.test_obj["deployments"], namespace=namespace)
+        self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
+        
+        helm_kwargs = self.test_obj.get_arg("helm_kwargs")
+        Logger.logger.info('install armo helm-chart')
+        self.add_and_upgrade_armo_to_repo()
+        self.install_armo_helm_chart(helm_kwargs=helm_kwargs)
+        self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360)
+
+        pods_list = list(map(lambda obj: obj['metadata']['name'], workload_objs))
+        Logger.logger.info(f"restarting pods: {pods_list}")
+        for pod in pods_list:
+            pod = self.wait_for_report(report_type=self.get_pod_if_ready, namespace=namespace, name=pod, timeout=180)
+            pod_name = pod[0].metadata.name
+            self.restart_pods(namespace=namespace, name=pod_name)
+        Logger.logger.info(f"restarted pods successfully")
+        
+
+        duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
+        TestUtil.sleep(2 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+
+        expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
+
+        Logger.logger.info("validating expected network neighbors")
+        self.validate_expected_network_neighbors_list(namespace=namespace, expected_network_neighbors_list=expected_network_neighbors_list)
+        Logger.logger.info("validated expected network neighbors")
+
+        expected_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_generated_network_policies"])
+
+        Logger.logger.info("validating expected generated network policies")
+        self.validate_expected_generated_network_policy_list(namespace=namespace, expected_generated_network_policy_list=expected_generated_network_policy_list)
+        Logger.logger.info("validated expected generated network policies")
+
+        
+        #TODO: check BE APIs
+
+        Logger.logger.info('delete armo namespace')
+        self.uninstall_armo_helm_chart()
+
+        return self.cleanup() 
 
 
+class NetworkPolicyMultipleReplicas(BaseNetworkPolicy):
+    def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
+        super(NetworkPolicyMultipleReplicas, self).__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
+                                                    kubernetes_obj=kubernetes_obj)
+
+    def start(self):
+        """
+        Test plan:
+        1. Install Armo helm-chart
+        2. Apply workloads
+        3. Generate different traffic for one pod
+        4. Validate network neighbors (data is aggregated from all pods)
+        5. Validate generated network policies (data is aggregated from all pods)
+        6. TODO: Check BE APIs
+        7. Uninstall Armo helm-chart
+        """
+
+        cluster, namespace = self.setup(apply_services=False)
+
+        helm_kwargs = self.test_obj.get_arg("helm_kwargs")
+
+        Logger.logger.info('install armo helm-chart')
+        self.add_and_upgrade_armo_to_repo()
+        self.install_armo_helm_chart(helm_kwargs=helm_kwargs)
+        self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360)
+        
+        Logger.logger.info('apply workloads')
+        workload_objs: list = self.apply_directory(path=self.test_obj["deployments"], namespace=namespace)
+        self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
+        
+        pods_list = list(map(lambda obj: obj['metadata']['name'], workload_objs))
+        pods = self.get_ready_pods(namespace=namespace, name=pods_list[0])
+        pod_name = pods[0].metadata.name
+
+        Logger.logger.info(f"pod {pod_name} is ready. Triggering exec command")
+        self.wait_for_report(timeout=180, report_type=self.run_exec_cmd, namespace=namespace, pod_name=pod_name, cmd="wget google.com")
 
 
+        duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
+        TestUtil.sleep(2 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+
+        expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
+
+        Logger.logger.info("validating expected network neighbors")
+        self.validate_expected_network_neighbors_list(namespace=namespace, expected_network_neighbors_list=expected_network_neighbors_list)
+        Logger.logger.info("validated expected network neighbors")
+
+        expected_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_generated_network_policies"])
+
+        Logger.logger.info("validating expected generated network policies")
+        self.validate_expected_generated_network_policy_list(namespace=namespace, expected_generated_network_policy_list=expected_generated_network_policy_list)
+        Logger.logger.info("validated expected generated network policies")
+
+        
+        #TODO: check BE APIs
+
+        Logger.logger.info('delete armo namespace')
+        self.uninstall_armo_helm_chart()
+
+        return self.cleanup()

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -1014,6 +1014,14 @@ class BaseK8S(BaseDockerizeTest):
         )
 
         return generated_network_policy
+    
+    def create_known_servers(self, body):
+        self.kubernetes_obj.client_CustomObjectsApi.create_cluster_custom_object(
+            group=statics.STORAGE_AGGREGATED_API_GROUP,
+            version=statics.STORAGE_AGGREGATED_API_VERSION,
+            plural=statics.KNOWN_SERVERS_PLURAL,
+            body=body,
+        )
 
     def get_network_neighbors(self, name: str, namespace: str):
         network_neighbors = self.kubernetes_obj.client_CustomObjectsApi.get_namespaced_custom_object(

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -650,6 +650,19 @@ class BaseK8S(BaseDockerizeTest):
                     replicas += i.spec.replicas
         return replicas
 
+    
+    def get_pod_if_ready(self, namespace: str, name: str):
+        """
+        Return pod if it is ready. Otherwise, raise an exception.
+        param: namespace: namespace of the pod
+        param: name: name of the pod
+        """
+        ready_pods = self.get_ready_pods(namespace=namespace, name=name)
+        for pod in ready_pods:
+            if name in pod.metadata.name and pod.metadata.namespace == namespace:
+                return pod
+        raise Exception("pod is not ready")
+
     def get_ready_pods(self, namespace, name: str = None):
         """
         :return: list of running pods with all containers ready
@@ -978,6 +991,41 @@ class BaseK8S(BaseDockerizeTest):
                 time.sleep(1)
         Logger.logger.info("exiting websocket thread")
 
+    def run_exec_cmd(self, pod_name: str, namespace: str, cmd: str):
+        """ 
+        Run a command inside a pod
+        :param pod_name: pod name
+        :param namespace: namespace
+        :param cmd: command to run
+        """
+        result = self.kubernetes_obj.exec_pod(namespace=namespace, name=pod_name, command=cmd)
+
+        if result[0] != 0:
+            raise Exception(f"failed to run command {cmd} on pod {pod_name} in namespace {namespace}")
+
+
+    def get_generated_network_policy(self, namespace: str, name: str):
+        generated_network_policy = self.kubernetes_obj.client_CustomObjectsApi.get_namespaced_custom_object(
+            group=statics.STORAGE_AGGREGATED_API_GROUP,
+            version=statics.STORAGE_AGGREGATED_API_VERSION,
+            name=name,
+            namespace=namespace,
+            plural=statics.GENERATED_NETWORK_POLICY_PLURAL,
+        )
+
+        return generated_network_policy
+
+    def get_network_neighbors(self, name: str, namespace: str):
+        network_neighbors = self.kubernetes_obj.client_CustomObjectsApi.get_namespaced_custom_object(
+            group=statics.STORAGE_AGGREGATED_API_GROUP,
+            version=statics.STORAGE_AGGREGATED_API_VERSION,
+            name=name,
+            namespace=namespace,
+            plural=statics.NETWORK_NEIGHBOR_PLURAL,
+        )
+
+        return network_neighbors
+    
     def get_SBOM_from_storage(self, SBOMKeys):
         SBOMs = []
         if isinstance(SBOMKeys, str):


### PR DESCRIPTION
## Type
Tests

___
## Description
This PR introduces tests for the network policy feature. The tests are implemented in Python and are designed to validate the functionality of network policies in a Kubernetes environment. The main changes include:
- Addition of new Python scripts implementing the network policy tests.
- Addition of test configurations for the network policy tests.
- Updates to the base Kubernetes and Helm classes to support the network policy tests.
- Addition of new statics for the network policy tests.
- Addition of a new Kubernetes deployment for the network policy tests.

___
## Main files walkthrough
<details> <summary>files:</summary>

- `tests_scripts/helm/network_policy.py`: This file contains the main implementation of the network policy tests. It includes four test classes: `NetworkPolicy`, `NetworkPolicyDataAppended`, `NetworkPolicyPodRestarted`, and `NetworkPolicyMultipleReplicas`. Each class represents a different test scenario for network policies.
- `configurations/system/tests_cases/network_policy_tests.py`: This file contains the test configurations for the network policy tests. Each test configuration includes the necessary parameters and expected results for a specific network policy test.
- `tests_scripts/kubernetes/base_k8s.py`: This file has been updated with new methods to support the network policy tests. These methods include `get_pod_if_ready`, `run_exec_cmd`, `get_generated_network_policy`, and `get_network_neighbors`.
- `configurations/system/tests.py`: This file has been updated to include the network policy tests in the list of all test names and in the method for getting a specific test.
- `systest_utils/statics.py`: This file has been updated with new statics for the network policy tests. These statics include `GENERATED_NETWORK_POLICY_PLURAL`, `NETWORK_NEIGHBOR_PLURAL`, `NETWORK_NEIGHBOR_KIND`, `HELM_NETWORK_POLICY_FEATURE`, `HELM_NODE_AGENT_LEARNING_PERIOD`, and `HELM_NODE_AGENT_UPDATE_PERIOD`.
- `tests_scripts/helm/base_helm.py`: This file has been updated to ensure that the node agent learning period and update period are not overwritten if they are already present in the helm kwargs.
- `systest_utils/systests_utilities.py`: This file has been updated with a new method `load_objs_from_json_files` to support the network policy tests. This method loads objects from JSON files, which are used as expected results in the tests.
- `configurations/k8s_workloads/deployments/busybox/busybox.yaml`: This file is a new Kubernetes deployment added for the network policy tests. It deploys a busybox pod, which is used in the `NetworkPolicyMultipleReplicas` test.
</details>

___
## User description
Add tests for network policy feature
