### PR TITLE
add sleep before test message check

### DIFF
--- a/tests_scripts/users_notifications/alert_notifications.py
+++ b/tests_scripts/users_notifications/alert_notifications.py
@@ -12,6 +12,8 @@ from ..helm.base_helm import BaseHelm
 
 NOTIFICATIONS_SVC_DELAY = 6 * 60
 
+TEST_MESSAGE_DELAY = 10
+
 TEST_NAMESPACE = "alerts"
 
 
@@ -202,6 +204,8 @@ class AlertNotifications(BaseHelm):
                 TestUtil.sleep(30, "waiting additional 30 seconds for messages to arrive")
 
     def assert_test_message_sent(self, before_test):
+        TestUtil.sleep(TEST_MESSAGE_DELAY, "waiting for test message")
         messages = self.test_obj["getMessagesFunc"](before_test)
-        assert len(messages) == 1, "expected to be only one message"
+        assert len(messages) > 0, "no messages found"
+        assert len(messages) < 2, "expected to be only one message"
         assert "Test Alert" in str(messages[0]), "expected message to be a Test Alert"


### PR DESCRIPTION
## Type
bug_fix


___

## Description
- A delay of 10 seconds has been introduced before checking for test messages in the `assert_test_message_sent` function. This is to ensure that the test messages have had enough time to arrive.
- The assertion for the number of messages has been updated. Previously, it was checking for exactly one message. Now, it checks that there are more than zero messages and less than two, ensuring that only one message is expected.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>alert_notifications.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        tests_scripts/users_notifications/alert_notifications.py<br><br>

**A delay has been added before checking for test messages to <br>ensure they have had time to arrive. The assertion for the <br>number of messages has been updated to check for more than <br>zero messages and less than two, ensuring that only one <br>message is expected.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/217/files#diff-060c88bdcfa726da38c03b70cd0a8200d036919e36d7aae93d871504ac2d8ec5"> +5/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
Signed-off-by: refaelm <refaelm@armosec.io>
