### PR TITLE
Remove unused methods and clean up code

### DIFF
--- a/tests_scripts/dockerize/base_dockerize_test.py
+++ b/tests_scripts/dockerize/base_dockerize_test.py
@@ -52,15 +52,7 @@ class BaseDockerizeTest(base_test.BaseTest):
     def cleanup(self, ignore_agent=False, ignore_containers_logs: bool = False,
                 **kwargs):
         agent_stat, summary = "", ""
-        self.test_summery_data.update(self.container_statistics)
-        for i in self.wlids[:]:
-            try:
-                jobs = self.backend.get_finished_jobs_of_wlid(i)
-                Logger.logger.info(
-                    f"Jobs of wlid: ({i}): {json.dumps(jobs['response'], indent=4)}")
-            except Exception as ex:
-                Logger.logger.error(
-                    f"failed to get_finished_jobs_of_wlid ({i}): {ex}")
+        self.test_summery_data.update(self.container_statistics)        
 
         if not ignore_containers_logs:
             # remove docker containers

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -267,11 +267,7 @@ class ScanWithKubescapeAsServiceTest(BaseHelm, BaseKubescape):
         kubescape_result = self.get_kubescape_as_server_last_result(cluster_name, port=port, report_guid=report_guid)
 
         Logger.logger.info('test result against backend results')
-        self.test_backend_vs_kubescape_result(report_guid=report_guid, kubescape_result=kubescape_result)
-
-        Logger.logger.info('test reported job results')
-        cluster_wlid = "wlid://cluster-{}".format(cluster_name)
-        self.check_kubescape_job_report_in_backend(report_guid=report_guid, cluster_wlid=cluster_wlid)
+        self.test_backend_vs_kubescape_result(report_guid=report_guid, kubescape_result=kubescape_result)      
 
         return report_guid
 
@@ -304,23 +300,6 @@ class ScanWithKubescapeAsServiceTest(BaseHelm, BaseKubescape):
 
         Logger.logger.info('test result against backend results')
         self.test_backend_vs_kubescape_result(report_guid=report_guid, kubescape_result=kubescape_result)
-
-        Logger.logger.info('test reported job results')
-        cluster_wlid = "wlid://cluster-{}".format(cluster_name)
-        self.check_kubescape_job_report_in_backend(report_guid=report_guid, cluster_wlid=cluster_wlid)
-
-    def check_kubescape_job_report_in_backend(self, report_guid, cluster_wlid):
-        be_jobs_report = self.get_job_report_info(report_guid=report_guid, cluster_wlid=cluster_wlid)
-
-        found = False
-        assert len(be_jobs_report) > 0, 'Received empty job report from backend'
-        for job in be_jobs_report:
-            if "done" == job["status"] \
-                    and "kubescapeScan" == job["action"] \
-                    and "Websocket" == job["reporter"]:
-                found = True
-                break
-        assert found, f"can't find a job report that indicates that kubescape finished successfully: {be_jobs_report}"
 
     def check_result_with_backend_cronjob(self, job, cluster_name, old_report_guid, port):
         sleep_time = 120
@@ -361,10 +340,6 @@ class ScanWithKubescapeAsServiceTest(BaseHelm, BaseKubescape):
 
             Logger.logger.info('test result against backend results, report_guid: {}'.format(report_guid))
             self.test_backend_vs_kubescape_result(report_guid=report_guid, kubescape_result=kubescape_result)
-
-            Logger.logger.info('test reported job results')
-            cluster_wlid = "wlid://cluster-{}".format(cluster_name)
-            self.check_kubescape_job_report_in_backend(report_guid=report_guid, cluster_wlid=cluster_wlid)
 
         if job["operation"] == "update":
             Logger.logger.info("update kubescape cronjob")

--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -1187,12 +1187,6 @@ class BaseKubescape(BaseK8S):
             framework_name, framework_report[_COMPLIANCE_SCORE_FIELD], be_cluster_overtime[statics.BE_CORDS_FIELD][_COMPLIANCE_SCORE_FIELD])
 
 
-
-    def get_job_report_info(self, report_guid, cluster_wlid: str = ""):
-        c_panel_info, t = self.wait_for_report(report_type=self.backend.get_job_report_info,
-                                               report_guid=report_guid, cluster_wlid=cluster_wlid)
-        return c_panel_info
-
     def is_ks_cronjob_created(self, framework_name, timeout=60):
         start = time.time()
         err = ""


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
This PR focuses on cleaning up the code by removing unused methods and endpoints related to job reports in the backend API. The main changes include:
- Removal of the `API_JOBREPORTS` endpoint from `backend_api.py`.
- Deletion of methods `get_finished_jobs_of_wlid`, `get_job_events_for_job`, and `get_job_report_info` from `backend_api.py`.
- Adaptation of test scripts (`base_dockerize_test.py`, `ks_microservice.py`, and `base_kubescape.py`) that were using the removed methods.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Code cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        infrastructure/backend_api.py<br><br>

**Removed the unused `API_JOBREPORTS` endpoint and associated <br>methods `get_finished_jobs_of_wlid` and <br>`get_job_events_for_job` from the `backend_api.py` file. <br>Also, the method `get_job_report_info` was removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/230/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245"> +0/-42</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_dockerize_test.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        tests_scripts/dockerize/base_dockerize_test.py<br><br>

**Removed the code that was using the <br>`get_finished_jobs_of_wlid` method from the `cleanup` method <br>in the `base_dockerize_test.py` file.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/230/files#diff-bc076e32b91e22718bc8fdb82d68cf33419c332a781e69b1d90b11936a3a22c5"> +1/-9</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        tests_scripts/helm/ks_microservice.py<br><br>

**Removed the code that was using the `get_job_report_info` <br>and `check_kubescape_job_report_in_backend` methods from the <br>`check_result_in_namespace_creation`, <br>`check_result_with_backend_demand`, and <br>`check_result_with_backend_cronjob` methods in the <br>`ks_microservice.py` file.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/230/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2"> +1/-26</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base_kubescape.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        tests_scripts/kubescape/base_kubescape.py<br><br>

**Removed the `get_job_report_info` method from the <br>`base_kubescape.py` file.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/230/files#diff-576a7629498d80e0394d13997ed798ebc8ed0f7bb881ce43f10c473605d6d66d"> +0/-6</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
