### PR TITLE
Update sleep duration in network_policy.py

### DIFF
--- a/tests_scripts/helm/base_network_policy.py
+++ b/tests_scripts/helm/base_network_policy.py
@@ -18,21 +18,18 @@ class BaseNetworkPolicy(BaseHelm):
         param expected_obj: expected object
         param namespace: namespace of the object
         """
-        assert actual_obj['apiVersion'] == expected_obj['apiVersion'], f"apiVersion is not equal, actual: {actual_obj['apiVersion']}, expected: {expected_obj['apiVersion']}"
-
-        assert actual_obj['kind'] == expected_obj['kind'], f"kind is not equal, actual: {actual_obj['kind']}, expected: {expected_obj['kind']}"
-
-
-        assert actual_obj['metadata']['name'] == expected_obj['metadata']['name'], f"name is not equal, actual: {actual_obj['metadata']['name']}, expected: {expected_obj['metadata']['name']}"
-        assert actual_obj['metadata']['namespace'] == namespace, f"namespace is not equal, actual: {actual_obj['metadata']['namespace']}, expected: {namespace}"
+        assert actual_obj['apiVersion'] == expected_obj['apiVersion'], f"in validate_basic_metadata: apiVersion is not equal, actual: {actual_obj['apiVersion']}, expected: {expected_obj['apiVersion']}, actual object: {actual_obj}, expected object: {expected_obj}"
+        assert actual_obj['kind'] == expected_obj['kind'], f"in validate_basic_metadata: kind is not equal, actual: {actual_obj['kind']}, expected: {expected_obj['kind']}, actual object: {actual_obj}, expected object: {expected_obj}"
+        assert actual_obj['metadata']['name'] == expected_obj['metadata']['name'], f"in validate_basic_metadata: name is not equal, actual: {actual_obj['metadata']['name']}, expected: {expected_obj['metadata']['name']}, actual object: {actual_obj}, expected object: {expected_obj}"
+        assert actual_obj['metadata']['namespace'] == namespace, f"in validate_basic_metadata: namespace is not equal, actual: {actual_obj['metadata']['namespace']}, expected: {namespace}, actual object: {actual_obj}, expected object: {expected_obj}"
 
 
         if 'annotations' in expected_obj['metadata']:
             for key, annotation in expected_obj['metadata']['annotations'].items():
-                assert actual_obj['metadata']['annotations'][key] == annotation, f"annotation {key} is not equal, actual: {actual_obj['metadata']['annotations'][key]}, expected: {annotation}"
+                assert actual_obj['metadata']['annotations'][key] == annotation, f"annotation {key} is not equal, actual: {actual_obj['metadata']['annotations'][key]}, expected: {annotation}, actual object: {actual_obj}, expected object: {expected_obj}"
 
         for key, label in expected_obj['metadata']['labels'].items():
-            assert actual_obj['metadata']['labels'][key] == label, f"label {key} is not equal, actual: {actual_obj['metadata']['labels'][key]}, expected: {label}"
+            assert actual_obj['metadata']['labels'][key] == label, f"label {key} is not equal, actual: {actual_obj['metadata']['labels'][key]}, expected: {label}, actual object: {actual_obj}, expected object: {expected_obj}"
         
     
     def validate_expected_network_neighbors_list(self, namespace, expected_network_neighbors_list):
@@ -139,7 +136,7 @@ class BaseNetworkPolicy(BaseHelm):
                     verified_entries.append(expected_entry)
                     break
     
-        assert len(verified_entries) == len(expected_entries), f"verified_entries length is not equal to expected_entries length, actual: {verified_entries}, expected: {expected_entries}"
+        assert len(verified_entries) == len(expected_entries), f"in validate_network_neighbor_entry: verified_entries length is not equal to expected_entries length, actual length: {len(verified_entries)}, expected length: {len(expected_entries)}, actual results: {verified_entries}, expected results: {expected_entries}"
 
     def validate_expected_network_neighbors_and_generated_network_policies_lists(self, namespace, expected_network_neighbors_list, expected_generated_network_policy_list):
         """
@@ -390,7 +387,7 @@ class BaseNetworkPolicy(BaseHelm):
                 verified_entries += 1
                 break
 
-        assert verified_entries == len(expected_network_policy_entries), f"verified_entries is not equal, actual: {verified_entries}, expected: {len(expected_network_policy_entries)}"
+        assert verified_entries == len(expected_network_policy_entries), f"in validate_network_policy_entry: verified_entries is not equal, actual: {verified_entries}, expected: {len(expected_network_policy_entries)}"
 
 
     def verify_network_policy_entries(self, expected_entries, actual_entries):
@@ -445,12 +442,12 @@ class BaseNetworkPolicy(BaseHelm):
         for expected_policy_ref in expected_policy_refs:
             for actual_policy_ref in actual_policy_refs:
                 if expected_policy_ref['dns'] == actual_policy_ref['dns']:
-                    assert expected_policy_ref['name'] == actual_policy_ref['name'], f"name is not equal, actual: {actual_policy_ref['name']}, expected: {expected_policy_ref['name']}"
-                    assert expected_policy_ref['server'] == actual_policy_ref['server'], f"server is not equal, actual: {actual_policy_ref['server']}, expected: {expected_policy_ref['server']}"
+                    assert expected_policy_ref['name'] == actual_policy_ref['name'], f"in validate_policy_refs: name is not equal, actual: {actual_policy_ref['name']}, expected: {expected_policy_ref['name']}, actual object: {actual_policy_ref}, expected object: {expected_policy_ref}"
+                    assert expected_policy_ref['server'] == actual_policy_ref['server'], f"in validate_policy_refs: server is not equal, actual: {actual_policy_ref['server']}, expected: {expected_policy_ref['server']}, actual object: {actual_policy_ref}, expected object: {expected_policy_ref}"
                     verified_refs += 1
                     break
 
-        assert verified_refs == len(expected_policy_refs), f"verified_refs is not equal, actual: {verified_refs}, expected: {len(expected_policy_refs)}"
+        assert verified_refs == len(expected_policy_refs), f"in validate_policy_refs: verified_refs is not equal, actual: {verified_refs}, expected: {len(expected_policy_refs)}"
     
 
     def cleanup(self, **kwargs):

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -45,7 +45,7 @@ class NetworkPolicy(BaseNetworkPolicy):
         self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(4 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         pod = self.wait_for_report(report_type=self.get_pod_if_ready, namespace=namespace, name="wikijs", timeout=180)
         pod_name = pod[0].metadata.name
@@ -55,7 +55,7 @@ class NetworkPolicy(BaseNetworkPolicy):
         self.wait_for_report(timeout=180, report_type=self.run_exec_cmd, namespace=namespace, pod_name=pod_name, cmd="curl https://wikipedia.org")
         
         update_period_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_UPDATE_PERIOD][:-1]
-        TestUtil.sleep(4 * int(update_period_in_seconds), "wait for node-agent update period", "info")
+        TestUtil.sleep(5 * int(update_period_in_seconds), "wait for node-agent update period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
 
@@ -126,7 +126,7 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
         self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(4 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
         expected_generated_network_policy_list = TestUtil.load_objs_from_json_files(self.test_obj["expected_generated_network_policies"])
@@ -143,7 +143,7 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
         self.wait_for_report(timeout=180, report_type=self.run_exec_cmd, namespace=namespace, pod_name=pod_name, cmd="curl https://wikipedia.org")
 
         update_period_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_UPDATE_PERIOD][:-1]
-        TestUtil.sleep(4 * int(update_period_in_seconds), "wait for node-agent update period", "info")
+        TestUtil.sleep(5 * int(update_period_in_seconds), "wait for node-agent update period", "info")
 
         Logger.logger.info("5. Validating in-cluster expected network neighbors and generated network policies after generating traffic")
 
@@ -206,7 +206,7 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(4 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
         expected_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_generated_network_policies"])
@@ -262,7 +262,7 @@ class NetworkPolicyMultipleReplicas(BaseNetworkPolicy):
 
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(4 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
         expected_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_generated_network_policies"])
@@ -327,7 +327,7 @@ class NetworkPolicyKnownServers(BaseNetworkPolicy):
         
         
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(4 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
         expected_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_generated_network_policies"])


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- The PR primarily enhances the error logging in `base_network_policy.py` by including the actual and expected objects in the assertion error messages. This will provide more context when an assertion fails.
- The PR also updates the sleep duration for the node-agent learning period and update period in `network_policy.py`. The sleep duration has been increased from 4 to 5 times the duration in seconds. This change will ensure that the tests wait sufficiently long for the node-agent to complete its learning and update periods.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_network_policy.py</strong><dd><code>Improve error logging in base_network_policy.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/base_network_policy.py
- Enhanced error messages in assertions to include the actual and <br>  expected objects.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/236/files#diff-35ac8c7feff5887b6f1a5260b2f73fa151cda6cc9f28e4024ec718c54a82a0f7">+11/-14</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_policy.py</strong><dd><code>Update sleep duration in network_policy.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/network_policy.py
- Increased the sleep duration for the node-agent learning period and <br>  update period from 4 to 5 times the duration in seconds.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/236/files#diff-83e690ba62dd64c5e40792cf88ae5cb24ecb8ffeeab4cf257e4dcb661bd9b3c0">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
