### PR TITLE
Update kubescape.io/status annotations to "ready"

### DIFF
--- a/configurations/network-policy/expected-network-neighbors/busybox-known-server.json
+++ b/configurations/network-policy/expected-network-neighbors/busybox-known-server.json
@@ -3,7 +3,7 @@
     "kind": "NetworkNeighbors",
     "metadata": {
         "annotations": {
-            "kubescape.io/status": "complete"
+            "kubescape.io/status": "ready"
         },
         "creationTimestamp": "2023-12-11T11:02:21Z",
         "labels": {

--- a/configurations/network-policy/expected-network-neighbors/busybox.json
+++ b/configurations/network-policy/expected-network-neighbors/busybox.json
@@ -3,7 +3,7 @@
     "kind": "NetworkNeighbors",
     "metadata": {
         "annotations": {
-            "kubescape.io/status": "complete"
+            "kubescape.io/status": "ready"
         },
         "creationTimestamp": "2023-12-03T16:29:26Z",
         "labels": {

--- a/configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json
@@ -3,7 +3,7 @@
     "kind": "NetworkNeighbors",
     "metadata": {
         "annotations": {
-            "kubescape.io/status": "complete"
+            "kubescape.io/status": "ready"
         },
         "creationTimestamp": "2023-12-03T09:04:43Z",
         "labels": {

--- a/configurations/network-policy/expected-network-neighbors/deployment-mariadb.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-mariadb.json
@@ -3,7 +3,7 @@
     "kind": "NetworkNeighbors",
     "metadata": {
         "annotations": {
-            "kubescape.io/status": "complete"
+            "kubescape.io/status": "ready"
         },
         "creationTimestamp": "2023-11-29T13:10:57Z",
         "labels": {

--- a/configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json
@@ -3,7 +3,7 @@
     "kind": "NetworkNeighbors",
     "metadata": {
         "annotations": {
-            "kubescape.io/status": "complete"
+            "kubescape.io/status": "ready"
         },
         "creationTimestamp": "2023-12-03T09:04:43Z",
         "labels": {

--- a/configurations/network-policy/expected-network-neighbors/deployment-nginx.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-nginx.json
@@ -3,7 +3,7 @@
     "kind": "NetworkNeighbors",
     "metadata": {
         "annotations": {
-            "kubescape.io/status": "complete"
+            "kubescape.io/status": "ready"
         },
         "creationTimestamp": "2023-11-29T13:10:57Z",
         "labels": {

--- a/configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
@@ -3,7 +3,7 @@
     "kind": "NetworkNeighbors",
     "metadata": {
         "annotations": {
-            "kubescape.io/status": "complete"
+            "kubescape.io/status": "ready"
         },
         "creationTimestamp": "2023-12-03T09:04:44Z",
         "labels": {

--- a/configurations/network-policy/expected-network-neighbors/deployment-wikijs.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-wikijs.json
@@ -3,7 +3,7 @@
         "kind": "NetworkNeighbors",
         "metadata": {
             "annotations": {
-                "kubescape.io/status": "complete"
+                "kubescape.io/status": "ready"
             },
             "creationTimestamp": "2023-11-29T13:10:58Z",
             "labels": {


### PR DESCRIPTION
## **Type**
Bug fix


___

## **Description**
This PR includes changes to the `kubescape.io/status` annotation in multiple JSON configuration files. The status has been updated from "complete" to "ready". The affected files include:
- busybox-known-server.json
- busybox.json
- deployment-mariadb-basic.json
- deployment-mariadb.json
- deployment-nginx-basic.json
- deployment-nginx.json
- deployment-wikijs-basic.json
- deployment-wikijs.json


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>busybox-known-server.json</strong><dd><code>Update status annotation in busybox-known-server.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/busybox-known-server.json
- Updated the `kubescape.io/status` annotation from "complete" to <br>  "ready".
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/238/files#diff-aadd7c9f80a285598cfa101102f89a8269e6bdcac76ddb94c9b8370f7e6f08f3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>busybox.json</strong><dd><code>Update status annotation in busybox.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/busybox.json
- Updated the `kubescape.io/status` annotation from "complete" to <br>  "ready".
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/238/files#diff-4a0349c146a0853e8f5d4bcaea8f8030d2c405ea5a3eba07642500385233ff38">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-mariadb-basic.json</strong><dd><code>Update status annotation in deployment-mariadb-basic.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json
- Updated the `kubescape.io/status` annotation from "complete" to <br>  "ready".
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/238/files#diff-ac5ddd45032334cfc9db1e4dd1aff420be64c0ab94187cbc2acf40e68aa8766f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-mariadb.json</strong><dd><code>Update status annotation in deployment-mariadb.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-mariadb.json
- Updated the `kubescape.io/status` annotation from "complete" to <br>  "ready".
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/238/files#diff-938f9b2078b8a891c0bd8548c7478cc24958b23927b4d8c82786324a7559f4d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-nginx-basic.json</strong><dd><code>Update status annotation in deployment-nginx-basic.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json
- Updated the `kubescape.io/status` annotation from "complete" to <br>  "ready".
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/238/files#diff-bdb82161e6ba62307b9b4aeb861b70355e9b2ead703624fe3768e7c9a3a17609">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-nginx.json</strong><dd><code>Update status annotation in deployment-nginx.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-nginx.json
- Updated the `kubescape.io/status` annotation from "complete" to <br>  "ready".
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/238/files#diff-b68b269760135f469e65df3c86f0a89f136186f7e096962a93904064221a5bda">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-wikijs-basic.json</strong><dd><code>Update status annotation in deployment-wikijs-basic.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
- Updated the `kubescape.io/status` annotation from "complete" to <br>  "ready".
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/238/files#diff-8ba39b31d15de75e9b2aeb2b3edb9b8bf99eee7a594f747a3897a482ea33fbf1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-wikijs.json</strong><dd><code>Update status annotation in deployment-wikijs.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-wikijs.json
- Updated the `kubescape.io/status` annotation from "complete" to <br>  "ready".
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/238/files#diff-cc9b7d4e85f926ecedeb82d87a2f5da9105cedcea505e7ed6bd7effba7aa3178">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
