### PR TITLE
Fix np tests

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -618,12 +618,12 @@
             "Backend"
         ],
         "target_repositories": [
-            "helm-chart",
-            "node-agent",
-            "storage",
-            "operator",
-            "cadashboardbe",
-            "event-ingester-service"
+            "helm-chart-dummy",
+            "node-agent-dummy",
+            "storage-dummy",
+            "operator-dummy",
+            "cadashboardbe-dummy",
+            "event-ingester-service-dummy"
         ],
         "description": "Checks network policies and network neighbors in-cluster and backend match to expected with multiple replicas",
         "skip_on_environment": ""

--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -56,7 +56,7 @@ class BaseHelm(BaseK8S):
             except:
                 pass
             if self.backend:
-                TestUtil.sleep(150, "Waiting for aggregation to end")
+                TestUtil.sleep(50, "Waiting for aggregation to end")
                 self.cluster_deleted = self.delete_cluster_from_backend()
 
         return super().cleanup(**kwargs)

--- a/tests_scripts/helm/base_network_policy.py
+++ b/tests_scripts/helm/base_network_policy.py
@@ -212,11 +212,8 @@ class BaseNetworkPolicy(BaseHelm):
         param namespace: namespace of the object
         param expected_workloads_list: list of expected workloads
         """
-        res, t = self.wait_for_report(timeout=100, 
-                                                sleep_interval=5,
-                                                report_type=self.backend.get_network_policies, 
-                                                cluster_name=cluster, 
-                                                namespace=namespace)
+        res = self.backend.get_network_policies(cluster_name=cluster, namespace=namespace)
+
         workloads_list = res[1]
         assert len(workloads_list) == len(expected_workloads_list), f"workloads_list length is not equal to expected_workloads_list length, actual: len:{len(workloads_list)}, expected: len:{len(expected_workloads_list)}; actual results: {workloads_list}, expected results: {expected_workloads_list}"
 
@@ -230,19 +227,10 @@ class BaseNetworkPolicy(BaseHelm):
         param expected_network_neighbors_list: list of expected network neighbors
         """
 
-        errors = []
         for i in range(0, len(expected_network_policy_list)):
             workload_name = expected_network_policy_list[i]['metadata']['labels']['kubescape.io/workload-name']
-            try:
-                res, t = self.wait_for_report(timeout=100, 
-                                        sleep_interval=5,
-                                        report_type=self.backend.get_network_policies_generate, 
-                                        cluster_name=cluster, 
-                                        workload_name=workload_name, 
-                                        namespace=namespace)
-            except Exception as e:
-                errors.append(e)
-                continue
+            res = self.backend.get_network_policies_generate(cluster_name=cluster, workload_name=workload_name, namespace=namespace)
+  
             
             backend_generated_network_policy = res[1]
             graph = res[2]
@@ -251,7 +239,6 @@ class BaseNetworkPolicy(BaseHelm):
 
             self.validate_expected_network_neighbors(namespace=namespace, actual_network_neighbors=graph, expected_network_neighbors=expected_network_neighbors_list[i])
 
-        assert len(errors) == 0, f"Errors in validate_expected_backend_generated_network_policy_list: {errors}"
 
     def convert_backend_network_policy_to_generated_network_policy(self, backend_network_policy) -> dict:
         """

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -2,7 +2,7 @@ from systest_utils.systests_utilities import TestUtil
 from tests_scripts.helm.base_network_policy import BaseNetworkPolicy
 from systest_utils import statics, Logger
 import json
-
+from tests_scripts import base_test
 
 
     
@@ -256,7 +256,7 @@ class NetworkPolicyMultipleReplicas(BaseNetworkPolicy):
 
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(6 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_network_neighbors"])
         expected_generated_network_policy_list = TestUtil.load_objs_from_json_files( self.test_obj["expected_generated_network_policies"])
@@ -334,7 +334,7 @@ class NetworkPolicyKnownServers(BaseNetworkPolicy):
         return self.cleanup()
 
 
-class NetworkPolicyKnownServersCache(BaseNetworkPolicy):
+class NetworkPolicyKnownServersCache(base_test.BaseTest):
     def __init__(self, test_obj=None, backend=None, kubernetes_obj=None, test_driver=None):
         super(NetworkPolicyKnownServersCache, self).__init__(test_driver=test_driver, test_obj=test_obj, backend=backend,
                                                     kubernetes_obj=kubernetes_obj)
@@ -351,5 +351,5 @@ class NetworkPolicyKnownServersCache(BaseNetworkPolicy):
         res_json = json.loads(res.text)
         assert len(res_json) > 0, f"Known servers cache is empty"
 
-        return self.cleanup()
+        return statics.SUCCESS, ""
         

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -21,7 +21,6 @@ class NetworkPolicy(BaseNetworkPolicy):
         4. Validating in-cluster expected network neighbors and generated network policies
         5. Validating backend expected network neighbors and generated network policies
         6. Check deletion flow
-        7. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -65,7 +64,15 @@ class NetworkPolicy(BaseNetworkPolicy):
         self.validate_expected_network_neighbors_and_generated_network_policies_lists(namespace=namespace, expected_network_neighbors_list=expected_network_neighbors_list, expected_generated_network_policy_list=expected_generated_network_policy_list)
 
         Logger.logger.info("5. Validating backend expected network neighbors and generated network policies")
-        self.validate_expected_backend_results(cluster=cluster, namespace=namespace, expected_workloads_list=workload_objs, expected_network_neighbors_list=expected_network_neighbors_list, expected_generated_network_policy_list=expected_generated_network_policy_list)
+        self.wait_for_report(timeout=120,
+                            sleep_interval=5,
+                            report_type=self.validate_expected_backend_results,
+                            cluster=cluster,
+                            namespace=namespace,
+                            expected_workloads_list=workload_objs,
+                            expected_network_neighbors_list=expected_network_neighbors_list,
+                            expected_generated_network_policy_list=expected_generated_network_policy_list
+                            )
 
 
         Logger.logger.info('6. Check deletion flow')
@@ -98,7 +105,6 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
         4. Generate traffic
         5. Validating in-cluster expected network neighbors and generated network policies after generating traffic
         6. Validating backend expected network neighbors and generated network policies after generating traffic
-        7. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -152,7 +158,15 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
         self.validate_expected_network_neighbors_and_generated_network_policies_lists(namespace=namespace, expected_network_neighbors_list=expected_updated_network_neighbors_list, expected_generated_network_policy_list=expected_updated_generated_network_policy_list)
 
         Logger.logger.info("6. Validating backend expected network neighbors and generated network policies after generating traffic")
-        self.validate_expected_backend_results(cluster=cluster, namespace=namespace, expected_workloads_list=workload_objs, expected_network_neighbors_list=expected_updated_network_neighbors_list, expected_generated_network_policy_list=expected_updated_generated_network_policy_list)
+        self.wait_for_report(timeout=120,
+                            sleep_interval=5,
+                            report_type=self.validate_expected_backend_results,
+                            cluster=cluster,
+                            namespace=namespace,
+                            expected_workloads_list=workload_objs,
+                            expected_network_neighbors_list=expected_updated_network_neighbors_list,
+                            expected_generated_network_policy_list=expected_updated_generated_network_policy_list
+                            )
 
         return self.cleanup()
 
@@ -170,7 +184,6 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         3. Restart workloads
         4. Validating in-cluster expected network neighbors and generated network policies
         5. Validating bakcned expected network neighbors and generated network policies
-        6. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -210,10 +223,17 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         Logger.logger.info("4. Validating in-cluster expected network neighbors and generated network policies")
         self.validate_expected_network_neighbors_and_generated_network_policies_lists(namespace=namespace, expected_network_neighbors_list=expected_network_neighbors_list, expected_generated_network_policy_list=expected_generated_network_policy_list)
 
-        Logger.logger.info("5. Validating backend expected network neighbors and generated network policies")        
-        self.validate_expected_backend_results(cluster=cluster, namespace=namespace, expected_workloads_list=workload_objs, expected_network_neighbors_list=expected_network_neighbors_list, expected_generated_network_policy_list=expected_generated_network_policy_list)
+        Logger.logger.info("5. Validating backend expected network neighbors and generated network policies")     
+        self.wait_for_report(timeout=120,
+                            sleep_interval=5,
+                            report_type=self.validate_expected_backend_results,
+                            cluster=cluster,
+                            namespace=namespace,
+                            expected_workloads_list=workload_objs,
+                            expected_network_neighbors_list=expected_network_neighbors_list,
+                            expected_generated_network_policy_list=expected_generated_network_policy_list
+                            )   
 
-        Logger.logger.info('6. Uninstall armo helm-chart')
 
         return self.cleanup() 
 
@@ -231,7 +251,6 @@ class NetworkPolicyMultipleReplicas(BaseNetworkPolicy):
         3. Generate different traffic for one pod
         4. Validating in-cluster expected network neighbors and generated network policies
         5. Validating backend expected network neighbors and generated network policies
-        6. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -265,9 +284,15 @@ class NetworkPolicyMultipleReplicas(BaseNetworkPolicy):
         self.validate_expected_network_neighbors_and_generated_network_policies_lists(namespace=namespace, expected_network_neighbors_list=expected_network_neighbors_list, expected_generated_network_policy_list=expected_generated_network_policy_list)
 
         Logger.logger.info("5. Validating backend expected network neighbors and generated network policies")
-        self.validate_expected_backend_results(cluster=cluster, namespace=namespace, expected_workloads_list=workload_objs, expected_network_neighbors_list=expected_network_neighbors_list, expected_generated_network_policy_list=expected_generated_network_policy_list)
-
-        Logger.logger.info('6. Uninstall armo helm-chart')
+        self.wait_for_report(timeout=120, 
+                            sleep_interval=5,
+                            report_type=self.validate_expected_backend_results, 
+                            cluster=cluster, 
+                            namespace=namespace,
+                            expected_workloads_list=workload_objs, 
+                            expected_network_neighbors_list=expected_network_neighbors_list, 
+                            expected_generated_network_policy_list=expected_generated_network_policy_list
+                            )
 
         return self.cleanup()
 
@@ -287,7 +312,6 @@ class NetworkPolicyKnownServers(BaseNetworkPolicy):
         4. Apply Known Servers
         5. Validating in-cluster expected network neighbors and generated network policies
         6. Validating backend expected network neighbors and generated network policies
-        7. Uninstall Armo helm-chart
         """
 
         cluster, namespace = self.setup(apply_services=False)
@@ -329,7 +353,15 @@ class NetworkPolicyKnownServers(BaseNetworkPolicy):
         self.validate_expected_network_neighbors_and_generated_network_policies_lists(namespace=namespace, expected_network_neighbors_list=expected_network_neighbors_list, expected_generated_network_policy_list=expected_generated_network_policy_list)
 
         Logger.logger.info("6. Validating backend expected network neighbors and generated network policies")
-        self.validate_expected_backend_results(cluster=cluster, namespace=namespace, expected_workloads_list=workload_objs, expected_network_neighbors_list=expected_network_neighbors_list, expected_generated_network_policy_list=expected_generated_network_policy_list)
+        self.wait_for_report(timeout=120,
+                            sleep_interval=5,
+                            report_type=self.validate_expected_backend_results,
+                            cluster=cluster,
+                            namespace=namespace,
+                            expected_workloads_list=workload_objs,
+                            expected_network_neighbors_list=expected_network_neighbors_list,
+                            expected_generated_network_policy_list=expected_generated_network_policy_list
+                            )
 
         return self.cleanup()
 


### PR DESCRIPTION
## **Type**
Tests


___

## **Description**
- Reduced the sleep time from 150 to 50 in the cleanup method of base_helm.py.
- Simplified the network policy validation in base_network_policy.py by removing the wait_for_report method call and directly calling the get_network_policies and get_network_policies_generate methods.
- Removed the error handling logic in validate_expected_backend_generated_network_policy_list method of base_network_policy.py.
- Refactored the network policy tests in network_policy.py by importing base_test, removing the uninstallation of Armo helm-chart from the test plans, adding wait_for_report method call before validating backend results, increasing sleep time in NetworkPolicyMultipleReplicas class, and changing the superclass of NetworkPolicyKnownServersCache class from BaseNetworkPolicy to base_test.BaseTest.
- Updated the target repositories for network_policy_multiple_replicas test in system_test_mapping.json.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_helm.py</strong><dd><code>Reduced sleep time in cleanup method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/base_helm.py
- Reduced the sleep time from 150 to 50 in the cleanup method.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/241/files#diff-821c02ceccfbba391f88d154d40cb796c6c8700a933156e354cd781f646e6c6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base_network_policy.py</strong><dd><code>Simplified network policy validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/base_network_policy.py
- Removed the wait_for_report method call and directly called the <br>  get_network_policies and get_network_policies_generate methods.
- Removed the error handling logic in <br>  validate_expected_backend_generated_network_policy_list method.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/241/files#diff-35ac8c7feff5887b6f1a5260b2f73fa151cda6cc9f28e4024ec718c54a82a0f7">+4/-17</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_policy.py</strong><dd><code>Refactored network policy tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/network_policy.py
- Imported base_test.
- Removed the uninstallation of Armo helm-chart from the test plans.
- Added wait_for_report method call before validating backend results in <br>  start method of NetworkPolicy, NetworkPolicyTrafficBeforeAndAfter, and <br>  NetworkPolicyKnownServers classes.
- Increased sleep time in start method of NetworkPolicyMultipleReplicas <br>  class.
- Changed the superclass of NetworkPolicyKnownServersCache class from <br>  BaseNetworkPolicy to base_test.BaseTest.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/241/files#diff-83e690ba62dd64c5e40792cf88ae5cb24ecb8ffeeab4cf257e4dcb661bd9b3c0">+50/-18</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Updated target repositories for a system test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json
- Changed the target repositories for network_policy_multiple_replicas <br>  test.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/241/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
