### PR TITLE
Patch default secrets

### DIFF
--- a/infrastructure/kubectl_wrapper.py
+++ b/infrastructure/kubectl_wrapper.py
@@ -262,22 +262,24 @@ class KubectlWrapper(object):
         return status
 
     # apply kubernetes command
-    def patch_workload(self, namespace: str, application: dict, kind: str, name: str = None):
+    def patch_workload(self, namespace: str, application: any, kind: str, name: str = None):
 
         if 'Namespace' in kind:
             return self.run(method=self.client_CoreV1Api.patch_namespace, name=name, body=application)
         elif 'Deployment' in kind:
             method = self.client_AppsV1Api.patch_namespaced_deployment
-        elif 'Service' in kind:
+        elif 'Service' == kind:
             method = self.client_CoreV1Api.patch_namespaced_service
+        elif 'ServiceAccount' == kind:
+            method = self.client_CoreV1Api.patch_namespaced_service_account
         # elif 'ReplicaSet' in kind:
         #     status = self.client_AppsV1Api.create_namespaced_replica_set(namespace=namespace, body=application)
         # elif 'StatefulSet' in kind:
         #     status = self.client_AppsV1Api.patch_namespaced_stateful_set(namespace=namespace, body=application)
         # elif 'DaemonSet' in kind:
         #     status = self.client_AppsV1Api.patch_namespaced_daemon_set(namespace=namespace, body=application)
-        # elif 'Secret' in kind:
-        #     status = self.client_CoreV1Api.create_namespaced_secret(namespace=namespace, body=application)
+        elif 'Secret' in kind:
+            method = self.client_CoreV1Api.patch_namespaced_secret
         else:
             raise Exception('Unsupported Kind ,{0}, patching workload failed'.format(kind))
         return self.run(method=method, namespace=namespace, name=name, body=application)

--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -21,7 +21,7 @@ class BaseHelm(BaseK8S):
         self.helm_branch = self.test_driver.kwargs.get("helm_branch", DEFAULT_BRANCH)
         self.local_helm_chart = self.test_driver.kwargs.get("local_helm_chart", None)
         self.print_kubescape_chart_logs: bool = TestUtil.get_arg_from_dict(self.test_driver.kwargs,
-                                                                             "print_kubescape_chart_logs", True)
+                                                                           "print_kubescape_chart_logs", True)
         self.port_forward_proc = None
         self.proxy_config = test_obj[("proxy_config", None)]
         self.enable_security = self.test_obj[("enable_security", True)]
@@ -81,7 +81,7 @@ class BaseHelm(BaseK8S):
             except:
                 pass
 
-    def install_armo_helm_chart(self, helm_kwargs: dict = None):
+    def install_armo_helm_chart(self, namespace: str = statics.CA_NAMESPACE_FROM_HELM_NAME, helm_kwargs: dict = None):
         if helm_kwargs is None:
             helm_kwargs = {}
 
@@ -118,11 +118,18 @@ class BaseHelm(BaseK8S):
         if "nodeAgent.config.updatePeriod" not in helm_kwargs:
             helm_kwargs.update({"nodeAgent.config.updatePeriod": self.filtered_sbom_update_time})
 
+        create_namespace = True
+        if self.docker_default_secret:
+            self.create_namespace(unique_name=False, name=namespace)
+            create_namespace = False
+
         HelmWrapper.install_armo_helm_chart(customer=self.backend.get_customer_guid() if self.backend != None else "",
                                             access_key=self.backend.get_access_key() if self.backend != None else "",
                                             server=self.test_driver.backend_obj.get_api_url(),
                                             cluster_name=self.kubernetes_obj.get_cluster_name(),
-                                            repo=self.helm_armo_repo, helm_kwargs=helm_kwargs)
+                                            namespace=namespace,
+                                            repo=self.helm_armo_repo, create_namespace=create_namespace,
+                                            helm_kwargs=helm_kwargs)
 
     def get_in_cluster_tags(self):
         component_tag = {}


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- Added handling for Docker secrets in Kubernetes tests. A new environment variable `docker_default_secret` was introduced to store the default Docker secret. If this variable is set, a Docker secret is created in the Kubernetes namespace.
- Enhanced the installation of the Armo Helm chart by allowing the specification of a namespace. If `docker_default_secret` is set, a Kubernetes namespace is created first, and then the Armo Helm chart is installed without creating a new namespace.
- Extended the capabilities of the `patch_workload` method in the Kubernetes wrapper to handle `ServiceAccount` and `Secret` kinds.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_k8s.py</strong><dd><code>Addition of Docker secret handling in Kubernetes tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/kubernetes/base_k8s.py
- Added a new environment variable `docker_default_secret` to store the <br>  default Docker secret.
- Added a new method `patch_docker_default_secret` to create a Docker <br>  secret in the Kubernetes namespace.
- Modified the `create_namespace` method to call <br>  `patch_docker_default_secret` if `docker_default_secret` is set.
- Various code formatting and indentation changes for better <br>  readability.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/247/files#diff-79b94c674f22539f1ac228368571a90c18903080e3baedc4e3d255c0a7edaf8a">+102/-52</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>helm_wrapper.py</strong><dd><code>Enhanced Helm chart installation with namespace handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/helm_wrapper.py
- Modified the `install_armo_helm_chart` method to accept `namespace` <br>  and `create_namespace` parameters.
- If `docker_default_secret` is set, a Kubernetes namespace is created <br>  first, and then the Armo Helm chart is installed without creating a new <br>  namespace.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/247/files#diff-edf55859b01aa9fb7e604cad70bf60c9192769d028bd48d5e3ffaa946a399434">+20/-17</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kubectl_wrapper.py</strong><dd><code>Extended Kubernetes workload patching capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/kubectl_wrapper.py
- Modified the `patch_workload` method to handle `ServiceAccount` and <br>  `Secret` kinds.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/247/files#diff-217696a861da873133ae25152ab3510b116a9fe1b39b312fb0bbdbc566347ea9">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_helm.py</strong><dd><code>Enhanced Helm test with namespace handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/base_helm.py
- Modified the `install_armo_helm_chart` method to accept a `namespace` <br>  parameter.
- If `docker_default_secret` is set, a Kubernetes namespace is created <br>  first, and then the Armo Helm chart is installed.
    </details>
  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/247/files#diff-821c02ceccfbba391f88d154d40cb796c6c8700a933156e354cd781f646e6c6a">+10/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
