### PR TITLE
fix inconsistent time format

### DIFF
--- a/tests_scripts/users_notifications/alert_notifications.py
+++ b/tests_scripts/users_notifications/alert_notifications.py
@@ -70,9 +70,10 @@ def get_messages_from_teams_channel(before_test):
 
 
 def get_messages_from_slack_channel(before_test):
-    Logger.logger.info('Attempting to read messages from slack before timestamp ' + str(before_test))
+    formatted_time = format(before_test, ".6f")
+    Logger.logger.info('Attempting to read messages from slack before timestamp ' + formatted_time)
     client = WebClient(token=get_env("SLACK_SYSTEM_TEST_TOKEN"))
-    result = client.conversations_history(channel=f'{get_env("SLACK_CHANNEL_ID")}', oldest=before_test)
+    result = client.conversations_history(channel=f'{get_env("SLACK_CHANNEL_ID")}', oldest=formatted_time)
     if result is not None and isinstance(result.data, dict) and 'messages' in result.data:
         return result.data['messages']
     else:


### PR DESCRIPTION
## **User description**
Signed-off-by: refaelm <refaelm@armosec.io>


___

## **Type**
bug_fix


___

## **Description**
- Fixed an inconsistency in time format when reading messages from Slack by formatting the `before_test` timestamp with six decimal places.
- Updated the log message to reflect the new formatted timestamp, ensuring consistency in log outputs.
- Adjusted the Slack API call to use the newly formatted timestamp, ensuring accurate message retrieval.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alert_notifications.py</strong><dd><code>Fix Inconsistent Time Format in Slack Notifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/users_notifications/alert_notifications.py
<li>Introduced <code>formatted_time</code> variable to format <code>before_test</code> timestamp <br>with six decimal places.<br> <li> Updated log message to include the new <code>formatted_time</code> for consistency.<br> <li> Modified <code>conversations_history</code> call to use <code>formatted_time</code> instead of <br><code>before_test</code>.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/268/files#diff-060c88bdcfa726da38c03b70cd0a8200d036919e36d7aae93d871504ac2d8ec5">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

