### PR TITLE
Remove deprecated tests names

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -103,119 +103,12 @@
         "description": "checks public registry scan capabilities",
         "skip_on_environment": ""
     },
-    "vulnerability_scanning": {
-        "target": [
-            "Backend",
-            "In cluster"
-        ],
-        "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
-        ],
-        "description": "checks public registry scan capabilities",
-        "skip_on_environment": ""
-    },
-    "vulnerability_scanning_trigger_scan_public_registry": {
-        "target": [
-            "Backend",
-            "In cluster"
-        ],
-        "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
-        ],
-        "description": "checks public registry scan capabilities",
-        "skip_on_environment": ""
-    },
-    "vulnerability_scanning_trigger_scan_public_registry_excluded": {
-        "target": [
-            "Backend",
-            "In cluster"
-        ],
-        "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
-        ],
-        "description": "checks public registry scan capabilities",
-        "skip_on_environment": ""
-    },
-    "vulnerability_scanning_trigger_scan_private_quay_registry": {
-        "target": [
-            "Backend",
-            "In cluster"
-        ],
-        "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
-        ],
-        "description": "checks public registry scan capabilities",
-        "skip_on_environment": ""
-    },
-    "vulnerability_scanning_triggering_with_cron_job": {
-        "target": [
-            "Backend",
-            "In cluster"
-        ],
-        "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
-        ],
-        "description": "checks public registry scan capabilities",
-        "skip_on_environment": ""
-    },
-    "vulnerability_scanning_test_public_registry_connectivity_by_backend": {
-        "target": [
-            "Backend",
-            "In cluster"
-        ],
-        "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
-        ],
-        "description": "checks public registry scan capabilities",
-        "skip_on_environment": ""
-    },
-    "vulnerability_scanning_test_public_registry_connectivity_excluded_by_backend": {
-        "target": [
-            "Backend",
-            "In cluster"
-        ],
-        "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
-        ],
-        "description": "checks public registry scan capabilities",
-        "skip_on_environment": ""
-    },
-    "vulnerability_scanning_proxy": {
-        "target": [
-            "Backend",
-            "In cluster"
-        ],
-        "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
-        ],
-        "description": "checks public registry scan capabilities",
-        "skip_on_environment": ""
-    },
     "relevancy_multiple_containers": {
         "target": [
-            "Backend",
             "In cluster"
         ],
         "target_repositories": [
-            "cadashboardbe",
-            "event-ingester-service",
-            "gateway"
+            "helm-chart"
         ],
         "description": "checks public registry scan capabilities",
         "skip_on_environment": ""


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed multiple deprecated test names that were related to vulnerability scanning, indicating a cleanup and potential refactoring of test infrastructure.
- Updated the `relevancy_multiple_containers` test to target a new repository (`helm-chart`), suggesting a shift in testing focus or an update in the testing framework.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Removal of Deprecated Test Names and Update of Test Repositories</code></dd></summary>
<hr>

system_test_mapping.json
<li>Removed deprecated test names related to vulnerability scanning.<br> <li> Updated target repositories for the <code>relevancy_multiple_containers</code> <br>test.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/269/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+1/-108</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

