### PR TITLE
fail the test if we failed to delete repo

### DIFF
--- a/tests_scripts/kubescape/scan.py
+++ b/tests_scripts/kubescape/scan.py
@@ -783,10 +783,7 @@ class ScanGitRepositoryAndSubmit(BaseKubescape):
         assert repository_info['repoName'] == designators_attributes['repoName'], f"Expected repoName to be {designators_attributes['repoName']} but got {repository_info['repoName']}"
         assert repository_info['branchName'] == designators_attributes['branch'], f"Expected branchName to be {designators_attributes['branch']} but got {repository_info['branchName']}"
         Logger.logger.info(f"Running test cleanup - deleting repository ({repoHash})")
-        try:
-            self.backend.delete_repository(repository_hash=repoHash)
-        except Exception as e:
-            Logger.logger.warning(f"failed to delete repository - {e}")
+        self.backend.delete_repository(repository_hash=repoHash)
         return statics.SUCCESS, ""
 
 class TestScanningScope(BaseKubescape):


### PR DESCRIPTION
## **User description**
Signed-off-by: refaelm <refaelm@armosec.io>


___

## **Type**
tests


___

## **Description**
- Removed the exception handling around repository deletion in the test cleanup process. This change ensures that tests will fail if there's an issue deleting the repository, improving test reliability by not masking potential errors.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scan.py</strong><dd><code>Ensure Test Fails on Repository Deletion Failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/kubescape/scan.py
<li>Removed try-except block around repository deletion in test cleanup, <br>ensuring the test fails if the repository cannot be deleted.


</details>
    

  </td>
  <td><a href="https:/armosec/system-tests/pull/271/files#diff-82106cd6bc2cc91c46c937db1d4baaf7ac2a93431a35fdee79e78921dc598b86">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

