### PR TITLE
enable slack and teams tests in config-service and uns

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -993,8 +993,8 @@
             "Backend"
         ],
         "target_repositories": [
-            "users-notification-service-dummy",
-            "config-service-dummy"
+            "users-notification-service",
+            "config-service"
         ],
         "description": "testing teams alert channels with compliance and vulnerabilities notifications",
         "skip_on_environment": ""
@@ -1004,8 +1004,8 @@
             "Backend"
         ],
         "target_repositories": [
-            "users-notification-service-dummy",
-            "config-service-dummy"
+            "users-notification-service",
+            "config-service"
         ],
         "description": "testing slack alert channels with compliance and vulnerabilities notifications",
         "skip_on_environment": ""


### PR DESCRIPTION
## **User description**
Signed-off-by: refaelm <refaelm@armosec.io>


___

## **Type**
enhancement


___

## **Description**
- Updated the `system_test_mapping.json` to target actual services instead of dummy ones for slack and teams alert channel tests. This change enables the integration tests to run against the `users-notification-service` and `config-service`, enhancing the test coverage and reliability.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Update Target Repositories for Slack and Teams Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json
<li>Updated the <code>target_repositories</code> for tests related to teams and slack <br>alert channels from dummy services to actual services <br>(<code>users-notification-service</code> and <code>config-service</code>).


</details>
    

  </td>
  <td><a href="https:/armosec/system-tests/pull/273/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

