### PR TITLE
Vuln views - Extend tm and add ignore image hash and repo 

### DIFF
--- a/configurations/system/tests_cases/vuln_scan_tests.py
+++ b/configurations/system/tests_cases/vuln_scan_tests.py
@@ -32,12 +32,7 @@ class VulnerabilityScanningTests(object):
         from os.path import join
         return TestConfiguration(
             name=inspect.currentframe().f_code.co_name,
-            test_obj=VulnerabilityV2Views,
-            services=join(DEFAULT_SERVICE_PATH, "viewsv2"),
-            secret="wikijs.yaml",
-            config_maps=join(DEFAULT_CONFIGMAP_PATH, "viewsv2"),
-            deployments=join(DEFAULT_DEPLOYMENT_PATH, "viewsv2"),   
-            database=supported_systemsAPI.WikiJS,       
+            test_obj=VulnerabilityV2Views, 
             proxy_config={"helm_proxy_url": statics.HELM_PROXY_URL}
         )
      
@@ -52,8 +47,7 @@ class VulnerabilityScanningTests(object):
             services=join(DEFAULT_SERVICE_PATH, "viewsv2"),
             secret="wikijs.yaml",
             config_maps=join(DEFAULT_CONFIGMAP_PATH, "viewsv2"),
-            deployments=join(DEFAULT_DEPLOYMENT_PATH, "viewsv2"),           
-            proxy_config={"helm_proxy_url": statics.HELM_PROXY_URL}
+            deployments=join(DEFAULT_DEPLOYMENT_PATH, "viewsv2")
         )
     
     


### PR DESCRIPTION
## **User description**
+ remove unnecessary steps


___

## **Type**
enhancement, tests


___

## **Description**
- Simplified test configurations in `vuln_scan_tests.py` by removing unnecessary parameters, making the test setup cleaner and more focused.
- Adjusted proxy configuration for `vuln_v2_views` to streamline test execution.
- In `vuln_scan.py`, streamlined the test setup process by removing redundant steps and increasing timeout values for critical operations, enhancing test reliability.
- Introduced support for ignoring image hash and repository details in vulnerability scan comparisons, aligning with new feature requirements.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vuln_scan_tests.py</strong><dd><code>Simplify Test Configurations and Adjust Proxy Settings</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/vuln_scan_tests.py
<li>Simplified test configurations by removing unnecessary parameters such <br>as <code>services</code>, <code>secret</code>, <code>config_maps</code>, and <code>deployments</code>.<br> <li> Adjusted proxy configuration for <code>vuln_v2_views</code> test case.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/276/files#diff-5a30ae714bdf65ead73819f4cdc8869036805e89f3fbc691cb5d70dd92a1fcde">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vuln_scan.py</strong><dd><code>Streamline Test Setup and Support Ignore Image Hash and Repo Feature</code></dd></summary>
<hr>

tests_scripts/helm/vuln_scan.py
<li>Streamlined the test setup process by removing steps related to <br>applying cluster resources.<br> <li> Increased timeout for verifying helm installation and waiting for <br>report arrival to backend.<br> <li> Added <code>timeout</code> parameter to <code>verify_running_pods</code> method calls.<br> <li> Ignored <code>digest</code>, <code>repository</code>, and <code>registry</code> fields in image details <br>comparison to accommodate new ignore image hash and repo feature.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/276/files#diff-288de96b50f4d3d32f61bc4d91633848bd020741853e6416e73f7c9a1ee415e0">+14/-28</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

