### PR TITLE
enable slack test in the dashboard and ingesters

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -1026,6 +1026,8 @@
             "Backend"
         ],
         "target_repositories": [
+            "cadashboardbe",
+            "event-ingester-service",
             "users-notification-service",
             "config-service"
         ],


### PR DESCRIPTION
## **User description**
Signed-off-by: refaelm <refaelm@armosec.io>


___

## **Type**
enhancement


___

## **Description**
- Added "cadashboardbe" and "event-ingester-service" to the list of target repositories in `system_test_mapping.json` to enable testing of slack alert channels with compliance and vulnerabilities notifications.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Add Services to Slack Test Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json
<li>Added "cadashboardbe" and "event-ingester-service" to <br>"target_repositories" for testing slack alert channels.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/278/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

