### PR TITLE
Revert "disable CSV verification through ws for kubescape release"

### DIFF
--- a/tests_scripts/kubescape/scan.py
+++ b/tests_scripts/kubescape/scan.py
@@ -276,10 +276,10 @@ class ScanWithExceptionToBackend(BaseKubescape):
                                         framework_name=self.test_obj.get_arg("policy_name").upper(),namespace="system-test")
 
         Logger.logger.info("Stage 2.3: Verify download of controls and resources")
-        # self.get_posture_controls_CSV(framework_name=self.test_obj.get_arg("policy_name").upper(),
-        #                               report_guid=first_report_guid)
-        # self.get_posture_resources_CSV(framework_name=self.test_obj.get_arg("policy_name").upper(),
-        #                                report_guid=first_report_guid)
+        self.get_posture_controls_CSV(framework_name=self.test_obj.get_arg("policy_name").upper(),
+                                      report_guid=first_report_guid)
+        self.get_posture_resources_CSV(framework_name=self.test_obj.get_arg("policy_name").upper(),
+                                       report_guid=first_report_guid)
 
         Logger.logger.info("Stage 3: Add exception to backend and test with backend")
         Logger.logger.info("Stage 3.1: Add exception to backend")


### PR DESCRIPTION
## **User description**
This reverts commit 0d6a1cf3a3ca0495f1a88b67000017682b2ca26e.


___

## **Type**
enhancement


___

## **Description**
- Re-enabled the CSV verification for controls and resources in the Kubescape scan tests, which was previously disabled. This change ensures that the CSV files for controls and resources are properly downloaded and verified during the tests.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scan.py</strong><dd><code>Re-enable CSV Verification in Kubescape Scan Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/kubescape/scan.py
<li>Re-enabled CSV verification for controls and resources in Kubescape <br>scan tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/291/files#diff-82106cd6bc2cc91c46c937db1d4baaf7ac2a93431a35fdee79e78921dc598b86">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

