### PR TITLE
add 2 min delay to slack test

### DIFF
--- a/tests_scripts/users_notifications/alert_notifications.py
+++ b/tests_scripts/users_notifications/alert_notifications.py
@@ -10,7 +10,7 @@ from infrastructure import KubectlWrapper
 from systest_utils import Logger, statics, TestUtil
 from ..helm.base_helm import BaseHelm
 
-NOTIFICATIONS_SVC_DELAY = 6 * 60
+NOTIFICATIONS_SVC_DELAY = 8 * 60
 
 TEST_MESSAGE_DELAY = 10
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Increased the notification service delay in the alert notifications test script from 6 minutes to 8 minutes to ensure reliability in Slack notifications testing.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alert_notifications.py</strong><dd><code>Increase Slack Notification Service Delay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/users_notifications/alert_notifications.py
<li>Increased the notification service delay from 6 minutes to 8 minutes.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/292/files#diff-060c88bdcfa726da38c03b70cd0a8200d036919e36d7aae93d871504ac2d8ec5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

