### PR TITLE
fix expectedin vuin views v2

### DIFF
--- a/configurations/expected-result/V2_VIEWS/cve_details.json
+++ b/configurations/expected-result/V2_VIEWS/cve_details.json
@@ -128,5 +128,5 @@
     },
     "workloadsCount": 1,
     "imagesCount": 1,
-    "ignoreRulesSummary": {}
+    "ignoreRulesSummary": null
 }


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Corrected the representation of "ignoreRulesSummary" in `cve_details.json` to accurately reflect an absence of ignore rules by changing it from an empty object (`{}`) to `null`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cve_details.json</strong><dd><code>Correct "ignoreRulesSummary" Representation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/expected-result/V2_VIEWS/cve_details.json
- Changed "ignoreRulesSummary" from an empty object to null.



</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/294/files#diff-eeeaf6a93fa7c06437888f6d9515ae238441c6be1c0ebb0fdc32796cc03cdb46">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

