### PR TITLE
fix synchronizer tests

### DIFF
--- a/tests_scripts/helm/synchronizer.py
+++ b/tests_scripts/helm/synchronizer.py
@@ -136,8 +136,8 @@ class BaseSynchronizer(BaseHelm):
                 be_resources = self.backend.get_kubernetes_resources(
                     cluster_name=cluster, namespace=namespace
                 )
-                # remove Namespace, Node objects from the list
-                kinds_to_ignore = ["Namespace", "Node"]
+                # remove non-workload objects from the list
+                kinds_to_ignore = ["Namespace", "Node", "ConfigMap"]
                 be_resources = list(filter(lambda x: BaseSynchronizer.backend_resource_kind(x) not in kinds_to_ignore, be_resources))
                 assert (
                     len(be_resources) == 0
@@ -164,8 +164,8 @@ class BaseSynchronizer(BaseHelm):
                     with_resource=True, cluster_name=cluster, namespace=namespace
                 )
 
-                # remove Namespace, Node objects from the list
-                kinds_to_ignore = ["Namespace", "Node"]
+                # remove non-workload objects from the list
+                kinds_to_ignore = ["Namespace", "Node", "ConfigMap"]
                 be_resources = list(filter(lambda x: BaseSynchronizer.backend_resource_kind(x) not in kinds_to_ignore, be_resources))
 
                 assert len(be_resources) > 0, "BE kubernetes resources is empty"


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Updated synchronizer tests to improve the accuracy of backend resources verification by including `ConfigMap` in the list of kinds to ignore.
- This ensures that non-workload objects such as `Namespace`, `Node`, and now `ConfigMap` are properly filtered out during the test validation process.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>synchronizer.py</strong><dd><code>Refine Filtering of Non-Workload Objects in Synchronizer Tests</code></dd></summary>
<hr>

tests_scripts/helm/synchronizer.py
<li>Updated the list of kinds to ignore in synchronizer tests to include <br><code>ConfigMap</code> along with <code>Namespace</code> and <code>Node</code>.<br> <li> This change aims to refine the filtering of non-workload objects in <br>the backend resources verification process.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/296/files#diff-f8e3397c2b0b9c3932cc1832d8d762d752f20ee7fd22dccaf36dc0963f80be12">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

