### PR TITLE
hardcoded kubescape cli version in test (temporary)

### DIFF
--- a/tests_scripts/kubescape/scan.py
+++ b/tests_scripts/kubescape/scan.py
@@ -240,7 +240,7 @@ class ScanWithExceptionToBackend(BaseKubescape):
 
         Logger.logger.info("Installing kubescape")
         # Logger.logger.info(self.install())
-        self.install()
+        self.install(branch="v3.0.7")
 
         Logger.logger.info("Delete all exception from backend")
         self.backend.delete_all_posture_exceptions(cluster_name=self.kubernetes_obj.get_cluster_name())


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Hardcoded the Kubescape CLI version to `v3.0.7` in the test script to ensure consistency and predictability in test environments.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scan.py</strong><dd><code>Hardcode Kubescape CLI Version in Test Script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/kubescape/scan.py
<li>Hardcoded the Kubescape CLI version to <code>v3.0.7</code> in the test script.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/297/files#diff-82106cd6bc2cc91c46c937db1d4baaf7ac2a93431a35fdee79e78921dc598b86">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

