### PR TITLE
build ks using go build

### DIFF
--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -403,16 +403,10 @@ class BaseKubescape(BaseK8S):
 
         ks_path = os.path.join(self.test_driver.temp_dir, "kubescape")
 
-        # build kubescape (make file) for non-windows machines
-        if platform.system() != "Windows" and os.path.exists(os.path.join(ks_path, "Makefile")):
-            return_code, return_obj = TestUtil.run_command(command_args=["make"], cwd=ks_path, timeout=1000)
-            assert not return_code, f"Failed to build kubescape (make) from branch {branch} : {return_obj.stderr}"
-            shutil.move(os.path.join(ks_path, "kubescape"), kubescape_exec)
-        else:
-            # build kubescape using go build
-            return_code, return_obj = TestUtil.run_command(command_args=["go", "build", "-o", kubescape_exec],
-                                                           cwd=ks_path, timeout=360)
-            assert not return_code, f"Failed to build kubescape (go build) from branch {branch} : {return_obj.stderr}"
+        # build kubescape using go build
+        return_code, return_obj = TestUtil.run_command(command_args=["go", "build", "-o", kubescape_exec],
+                                                        cwd=ks_path, timeout=360)
+        assert not return_code, f"Failed to build kubescape (go build) from branch {branch} : {return_obj.stderr}"
 
         self.kubescape_exec = kubescape_exec
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Simplified the Kubescape build process in the test script to consistently use `go build` across all platforms, removing the previous conditional logic for non-Windows platforms.
- This change makes the build process more straightforward and potentially reduces build errors by relying on a single method.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_kubescape.py</strong><dd><code>Simplify Kubescape Build Process in Test Script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/kubescape/base_kubescape.py
<li>Simplified the build process of kubescape in the test script to use <code>go </code><br><code>build</code> for all platforms.<br> <li> Removed conditional build steps for non-Windows platforms using <br>Makefile.<br> <li> Ensured the build fails with an assert statement if <code>go build</code> <br>encounters an error.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/298/files#diff-576a7629498d80e0394d13997ed798ebc8ed0f7bb881ce43f10c473605d6d66d">+4/-10</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

