### PR TITLE
Ignore new resource hash field in vuln workload

### DIFF
--- a/tests_scripts/helm/vuln_scan.py
+++ b/tests_scripts/helm/vuln_scan.py
@@ -924,7 +924,7 @@ class VulnerabilityV2Views(BaseVulnerabilityScanning):
         if len(wl_summary) == 0:
             raise Exception('no results for httpd-proxy with exploitable filters (check possible exploitability change)')
         
-        wl_excluded_paths = {"root['cluster']", "root['namespace']","root['wlid']", "root['clusterShortName']", "root['customerGUID']", "root['lastScanTime']"}
+        wl_excluded_paths = {"root['cluster']", "root['namespace']","root['wlid']","root['resourceHash']", "root['clusterShortName']", "root['customerGUID']", "root['lastScanTime']"}
         wl_summary = wl_summary[0] 
         if updateExpected:
             TestUtil.save_expceted_json(wl_summary, "configurations/expected-result/V2_VIEWS/wl_filtered.json")     


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- This PR adds the `root['resourceHash']` field to the exclusion list used during the comparison of vulnerability scan workload summaries. This ensures that changes in the resource hash do not affect the test outcomes, improving the robustness of the tests.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vuln_scan.py</strong><dd><code>Include New Resource Hash Field in Exclusion List</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/vuln_scan.py
<li>Added <code>root['resourceHash']</code> to the list of excluded paths in <br>vulnerability scan workload summary comparison.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/302/files#diff-288de96b50f4d3d32f61bc4d91633848bd020741853e6416e73f7c9a1ee415e0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

