### PR TITLE
Add default timeout value if not provided

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -131,7 +131,10 @@ def deco_cookie(func):
                     kwargs["params"]["customerGUID"] = ControlPanelAPIObj.selected_tenant_id
 
         kwargs['headers'] = kwargs.get("headers", ControlPanelAPIObj.auth)
-        kwargs["timeout"] = kwargs.get("timeout", 21)
+
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = kwargs.get("timeout", 21)
+            
         kwargs["verify"] = kwargs.get("verify", ControlPanelAPIObj.verify)
 
         result = func(*args, **kwargs)


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced the logic for setting a default timeout in `backend_api.py` to avoid overwriting an existing timeout value if provided.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Refine Timeout Setting Logic in Backend API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/backend_api.py
<li>Added a check to ensure <code>timeout</code> is not already present in <code>kwargs</code> <br>before setting a default value.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/303/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

