### PR TITLE
Ignore comp version

### DIFF
--- a/tests_scripts/helm/vuln_scan.py
+++ b/tests_scripts/helm/vuln_scan.py
@@ -1001,6 +1001,7 @@ class VulnerabilityV2Views(BaseVulnerabilityScanning):
                               "root['componentInfo']['pathsInfo'][0]['clusterName']",
                               "root['componentInfo']['pathsInfo'][0]['namespace']",
                               "root['componentInfo']['pathsInfo'][0]['imageHash']",
+                              "root['componentInfo']['version']",
                               "root['cvssInfo']['baseScore']"}
         if updateExpected:
             TestUtil.save_expceted_json(cve, "configurations/expected-result/V2_VIEWS/cve_details.json")


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- This PR enhances the vulnerability scanning test script by excluding the component version from the comparison of expected and actual CVE details. This change aims to reduce test fragility related to version changes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vuln_scan.py</strong><dd><code>Include Component Version in CVE Details Test Exclusion</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/vuln_scan.py
<li>Added <code>root['componentInfo']['version']</code> to the list of excluded paths <br>during CVE details comparison in tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/306/files#diff-288de96b50f4d3d32f61bc4d91633848bd020741853e6416e73f7c9a1ee415e0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

