### PR TITLE
Increased learningPeriod of relevancy_multiple_containers

### DIFF
--- a/configurations/system/tests_cases/relevant_vuln_scanning_tests.py
+++ b/configurations/system/tests_cases/relevant_vuln_scanning_tests.py
@@ -68,7 +68,7 @@ class RelevantVulnerabilityScanningTests(object):
                                     ("wordpress", "configurations/expected-result/filteredCVEs/wordpress.json")],
             helm_kwargs={statics.HELM_STORAGE_FEATURE: True,
                          statics.HELM_RELEVANCY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
-                         "nodeAgent.config.learningPeriod": "1m",
+                         "nodeAgent.config.learningPeriod": "2m",
                          "nodeAgent.config.updatePeriod": "0.5m"
                          }
         )


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Increased the learning period for the `nodeAgent` configuration in the `relevancy_multiple_containers` test case to improve the accuracy of vulnerability scanning by allowing more time for learning.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>relevant_vuln_scanning_tests.py</strong><dd><code>Increase Learning Period in Vulnerability Scanning Test</code>&nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/relevant_vuln_scanning_tests.py
<li>Increased the <code>nodeAgent.config.learningPeriod</code> from "1m" to "2m" in the <br><code>relevancy_multiple_containers</code> test case.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/307/files#diff-e7ef65c49e1d20c0e12403d538345a67f3b9b8758748a6081a418d65dd86d778">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

