### PR TITLE
Fix/sync checks

### DIFF
--- a/configurations/system/tests_cases/relevant_vuln_scanning_tests.py
+++ b/configurations/system/tests_cases/relevant_vuln_scanning_tests.py
@@ -68,7 +68,7 @@ class RelevantVulnerabilityScanningTests(object):
                                     ("wordpress", "configurations/expected-result/filteredCVEs/wordpress.json")],
             helm_kwargs={statics.HELM_STORAGE_FEATURE: True,
                          statics.HELM_RELEVANCY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
-                         "nodeAgent.config.learningPeriod": "2m",
+                         "nodeAgent.config.learningPeriod": "1m",
                          "nodeAgent.config.updatePeriod": "0.5m"
                          }
         )

--- a/configurations/system/tests_cases/relevant_vuln_scanning_tests.py
+++ b/configurations/system/tests_cases/relevant_vuln_scanning_tests.py
@@ -68,7 +68,7 @@ class RelevantVulnerabilityScanningTests(object):
                                     ("wordpress", "configurations/expected-result/filteredCVEs/wordpress.json")],
             helm_kwargs={statics.HELM_STORAGE_FEATURE: True,
                          statics.HELM_RELEVANCY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
-                         "nodeAgent.config.learningPeriod": "1m",
+                         "nodeAgent.config.learningPeriod": "2m",
                          "nodeAgent.config.updatePeriod": "0.5m"
                          }
         )

--- a/tests_scripts/helm/synchronizer.py
+++ b/tests_scripts/helm/synchronizer.py
@@ -160,6 +160,8 @@ class BaseSynchronizer(BaseHelm):
             iterations -= 1
             try:
                 cluster_resources = list_func(namespace) if list_func else self.get_all_workloads_in_namespace(namespace)
+                cluster_resources_kinds = [i.kind for i in cluster_resources]
+
                 be_resources = self.backend.get_kubernetes_resources(
                     with_resource=True, cluster_name=cluster, namespace=namespace
                 )
@@ -167,6 +169,7 @@ class BaseSynchronizer(BaseHelm):
                 # remove non-workload objects from the list
                 kinds_to_ignore = ["Namespace", "Node", "ConfigMap"]
                 be_resources = list(filter(lambda x: BaseSynchronizer.backend_resource_kind(x) not in kinds_to_ignore, be_resources))
+                be_resources = list(filter(lambda x: BaseSynchronizer.backend_resource_kind(x) in cluster_resources_kinds, be_resources))
 
                 assert len(be_resources) > 0, "BE kubernetes resources is empty"
                 assert len(be_resources) == len(cluster_resources), (


### PR DESCRIPTION
## **Type**
Enhancement, Bug fix


___

## **Description**
- Extended the learning period in `relevancy_multiple_containers` test from 1 minute to 2 minutes to enhance test reliability.
- Improved synchronization checks in `verify_backend_resources` by ensuring only relevant resource kinds are compared, enhancing the accuracy of the synchronization process.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>relevant_vuln_scanning_tests.py</strong><dd><code>Extend Learning Period in Vulnerability Scanning Test</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/relevant_vuln_scanning_tests.py
<li>Increased the learning period for node agent configuration from 1 <br>minute to 2 minutes in the <code>relevancy_multiple_containers</code> test case.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/322/files#diff-e7ef65c49e1d20c0e12403d538345a67f3b9b8758748a6081a418d65dd86d778">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>synchronizer.py</strong><dd><code>Improve Resource Synchronization Checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/synchronizer.py
<li>Added extraction of resource kinds from cluster resources.<br> <li> Filtered backend resources to include only those kinds that exist in <br>cluster resources.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/322/files#diff-f8e3397c2b0b9c3932cc1832d8d762d752f20ee7fd22dccaf36dc0963f80be12">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

