### PR TITLE
specify security_risks_ids in sr_ac_scan_status

### DIFF
--- a/configurations/system/tests_cases/security_risks_tests.py
+++ b/configurations/system/tests_cases/security_risks_tests.py
@@ -54,7 +54,7 @@ class SecurityRisksTests(object):
         return TestConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=ScanStatusWithKubescapeHelmChart,
-            test_job=[{"trigger_by": "scan_on_start"}],
+            test_job=[{"trigger_by": "scan_on_start", "security_risks_ids": ["R_0005"]}],
             test_scenario="attack-chain-5",
             fix_object="control",
             relevancy_enabled=False,


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- This PR enhances the test configuration by specifying `security_risks_ids` in the `sr_ac_scan_status` function to include specific security risk identifiers, improving the precision of security testing.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security_risks_tests.py</strong><dd><code>Enhance Test Configuration with Security Risks IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/security_risks_tests.py
<li>Added <code>security_risks_ids</code> with value ["R_0005"] to the <code>test_job</code> <br>dictionary in the <code>sr_ac_scan_status</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/327/files#diff-ecc535a3fe03cfa50ec7c6f9025f90ecbaa51985719a59d32c067c818b0fa6a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

