### PR TITLE
Fix bug in SecurityRisksScenarioManager exception handling logic

### DIFF
--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -338,7 +338,7 @@ class SecurityRisksScenarioManager(ScenarioManager):
         """
         ignore_keys = {'relation', 'lastUpdated', 'supportsSmartRemediation', 'namespace', 
                    'cursor', 'k8sResourceHash', 'cluster', 'attackChainID', 'firstSeen', 
-                   'clusterShortName', 'lastTimeDetected', 'reportGUID', 'resourceID', 'isNew', 'k8sResourceHash'}
+                   'clusterShortName', 'lastTimeDetected', 'reportGUID', 'resourceID', 'isNew', 'exceptionPolicyGUID'}
     
         if 'total' in result and 'total' in expected:
             assert result['total']['value'] == expected['total']['value'], f"'Total' value mismatch: result: {result['total']['value']} != expected: {expected['total']['value']}"


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Updated the `ignore_keys` set in the `check_security_risks_resources_results` method to improve exception handling by removing 'k8sResourceHash' and adding 'exceptionPolicyGUID'.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scenarios_manager.py</strong><dd><code>Update Ignore Keys in Security Risk Scenario Manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

systest_utils/scenarios_manager.py
<li>Removed 'k8sResourceHash' from the ignore_keys set in the <br>check_security_risks_resources_results method.<br> <li> Added 'exceptionPolicyGUID' to the ignore_keys set.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/331/files#diff-45b40c85bafc6685da4f909cffb6852947ec4525688eb921c8f1f1ac5b4da638">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

