### PR TITLE
disable slack+teams tests to run on prod util we overcome the too man…

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -1146,7 +1146,7 @@
             "config-service"
         ],
         "description": "testing teams alert channels with compliance and vulnerabilities notifications",
-        "skip_on_environment": ""
+        "skip_on_environment": "production"
     },
     "slack_alerts": {
         "target": [
@@ -1159,7 +1159,7 @@
             "config-service"
         ],
         "description": "testing slack alert channels with compliance and vulnerabilities notifications",
-        "skip_on_environment": ""
+        "skip_on_environment": "production"
     },
     "sr_detect_and_resolve_attack_chain": {
         "target": [


### PR DESCRIPTION
## **User description**
…y requests issue that we faced with frontegg


___

## **Type**
tests


___

## **Description**
- Temporarily disabled Slack and Teams alert channel tests on the production environment to address the issue of too many requests with Frontegg.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Disable Slack and Teams Tests on Production Environment</code>&nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json
<li>Updated <code>skip_on_environment</code> for "teams_alerts" to "production"<br> <li> Updated <code>skip_on_environment</code> for "slack_alerts" to "production"<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/333/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

