### PR TITLE
Cli operator test

### DIFF
--- a/configurations/system/tests_cases/ks_microservice_test.py
+++ b/configurations/system/tests_cases/ks_microservice_test.py
@@ -392,7 +392,7 @@ class KSMicroserviceTests(object):
         return TestConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=ControlClusterFromCLI,
-            cli_args={"scan": True, "trigger": "config"},
+            cli_args={"scan": True, "trigger": "configurations"},
         )
 
     @staticmethod
@@ -401,7 +401,7 @@ class KSMicroserviceTests(object):
         return TestConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=ControlClusterFromCLI,
-            cli_args={"scan": True, "trigger": "config", "exclude-namespaces": ["kubescape"]},
+            cli_args={"scan": True, "trigger": "configurations", "exclude-namespaces": ["kubescape"]},
         )
 
     @staticmethod
@@ -410,7 +410,7 @@ class KSMicroserviceTests(object):
         return TestConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=ControlClusterFromCLI,
-            cli_args={"scan": True, "trigger": "config", "include-namespaces": ["kubescape"]},
+            cli_args={"scan": True, "trigger": "configurations", "include-namespaces": ["kubescape"]},
         )
 
     @staticmethod
@@ -419,7 +419,7 @@ class KSMicroserviceTests(object):
         return TestConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=ControlClusterFromCLI,
-            cli_args={"scan": True, "trigger": "config", "host-scanner-enabled": True},
+            cli_args={"scan": True, "trigger": "configurations", "host-scanner-enabled": True},
         )
 
     @staticmethod
@@ -428,7 +428,7 @@ class KSMicroserviceTests(object):
         return TestConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=ControlClusterFromCLI,
-            cli_args={"scan": True, "trigger": "config", "submit": True},
+            cli_args={"scan": True, "trigger": "configurations", "submit": True},
         )
 
     @staticmethod
@@ -437,7 +437,7 @@ class KSMicroserviceTests(object):
         return TestConfiguration(
             name=inspect.currentframe().f_code.co_name,
             test_obj=ControlClusterFromCLI,
-            cli_args={"scan": True, "trigger": "config", "frameworks": ["MITRE"]},
+            cli_args={"scan": True, "trigger": "configurations", "frameworks": ["MITRE"]},
         )
 
     @staticmethod

--- a/configurations/system/tests_cases/relevant_vuln_scanning_tests.py
+++ b/configurations/system/tests_cases/relevant_vuln_scanning_tests.py
@@ -68,7 +68,7 @@ class RelevantVulnerabilityScanningTests(object):
                                     ("wordpress", "configurations/expected-result/filteredCVEs/wordpress.json")],
             helm_kwargs={statics.HELM_STORAGE_FEATURE: True,
                          statics.HELM_RELEVANCY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
-                         "nodeAgent.config.learningPeriod": "1m",
+                         "nodeAgent.config.learningPeriod": "2m",
                          "nodeAgent.config.updatePeriod": "0.5m"
                          }
         )


### PR DESCRIPTION
## **Type**
Tests, Enhancement


___

## **Description**
- Updated CLI arguments in multiple test configurations within `ks_microservice_test.py` to reflect a change in the trigger parameter from "config" to "configurations".
- Increased the learning period setting from 1 minute to 2 minutes in the `relevancy_multiple_containers` test in `relevant_vuln_scanning_tests.py` to potentially improve the accuracy of the test results.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice_test.py</strong><dd><code>Update CLI Arguments in Test Configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/ks_microservice_test.py
<li>Updated the 'cli_args' dictionary in multiple test configurations to <br>change the 'trigger' value from "config" to "configurations".<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/335/files#diff-d6e0a110181364d760a49881a441fcb09a5131f2c47261bea53f338f5ef8768e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>relevant_vuln_scanning_tests.py</strong><dd><code>Increase Learning Period in Vulnerability Scanning Test</code>&nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/relevant_vuln_scanning_tests.py
<li>Increased the 'learningPeriod' from "1m" to "2m" in the <br>'nodeAgent.config' settings for the relevancy_multiple_containers <br>test.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/335/files#diff-e7ef65c49e1d20c0e12403d538345a67f3b9b8758748a6081a418d65dd86d778">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

