### PR TITLE
check cluster scan status, not global field

### DIFF
--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -579,29 +579,33 @@ class SecurityRisksScenarioManager(ScenarioManager):
 
         Logger.logger.info("validating scan status of attack chains is processing")
         r, t = self.wait_for_report(
-            self.verify_global_field_in_scan_status, 
+            self.verify_cluster_field_in_scan_status, 
             timeout=60,
+            cluster_name=self.cluster,
             expected_field='attackChainsProcessingStatus',
             expectedStatus='processing'
             )
         Logger.logger.info("validating scan status of security risks is processing")
         r, t = self.wait_for_report(
-            self.verify_global_field_in_scan_status, 
+            self.verify_cluster_field_in_scan_status, 
             timeout=1,
+            cluster_name=self.cluster,
             expected_field='securityRisksProcessingStatus',
             expectedStatus='processing'
             )
         Logger.logger.info("validating scan status of attack chains is done")
         r, t = self.wait_for_report(
-            self.verify_global_field_in_scan_status, 
+            self.verify_cluster_field_in_scan_status, 
             timeout=600,
+            cluster_name=self.cluster,
             expected_field='attackChainsProcessingStatus',
             expectedStatus='done'
             )
         Logger.logger.info("validating scan status of security risks is done")
         r, t = self.wait_for_report(
-            self.verify_global_field_in_scan_status, 
+            self.verify_cluster_field_in_scan_status, 
             timeout=600,
+            cluster_name=self.cluster,
             expected_field='securityRisksProcessingStatus',
             expectedStatus='done'
             )
@@ -611,6 +615,14 @@ class SecurityRisksScenarioManager(ScenarioManager):
         r = self.backend.get_scan_status()
         response = json.loads(r.text)
         assert response[expected_field] == expectedStatus, f"Expected {expected_field} to be {expectedStatus}, got {response[expected_field]}. Response: {response}"
+        return True
+    
+    def verify_cluster_field_in_scan_status(self, cluster_name, expected_field, expectedStatus)-> bool:
+        r = self.backend.get_scan_status()
+        response = json.loads(r.text)
+        for cluster_response in response['clusterScansStatus']:
+            if cluster_response['clusterName'] == cluster_name:
+                assert cluster_response[expected_field] == expectedStatus, f"Expected {expected_field} to be {expectedStatus}, got {cluster_response[expected_field]}. Response: {response}"
         return True
         
     def verify_cluster_lastPostureScanTriggered_time(self, cluster_name, trigger_time)-> bool:

--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -610,7 +610,7 @@ class SecurityRisksScenarioManager(ScenarioManager):
     def verify_global_field_in_scan_status(self, expected_field, expectedStatus)-> bool:
         r = self.backend.get_scan_status()
         response = json.loads(r.text)
-        assert response[expected_field] == expectedStatus, f"Expected {expected_field} to be {expectedStatus}, got {response[expected_field]}"
+        assert response[expected_field] == expectedStatus, f"Expected {expected_field} to be {expectedStatus}, got {response[expected_field]}. Response: {response}"
         return True
         
     def verify_cluster_lastPostureScanTriggered_time(self, cluster_name, trigger_time)-> bool:


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- The assert message within the `verify_global_field_in_scan_status` method now includes the full response to provide more detailed error information when the expected scan status does not match the actual status.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scenarios_manager.py</strong><dd><code>Enhance Assert Message with Full Response in Scan Status Verification</code></dd></summary>
<hr>

systest_utils/scenarios_manager.py
<li>Improved the assert message in <code>verify_global_field_in_scan_status</code> by <br>including the full response in the error output.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/342/files#diff-45b40c85bafc6685da4f909cffb6852947ec4525688eb921c8f1f1ac5b4da638">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

