### PR TITLE
use random name for user alert channel test

### DIFF
--- a/tests_scripts/users_notifications/alert_channels.py
+++ b/tests_scripts/users_notifications/alert_channels.py
@@ -1,6 +1,6 @@
 import json
 
-from systest_utils import Logger
+from systest_utils import Logger, TestUtil
 from .base_notifications import BaseNotifications
 
 CLUSTER_NAME = "cluster"
@@ -23,6 +23,7 @@ class AlertChannels(BaseNotifications):
         Logger.logger.info("Stage 2: Create new alert channel")
         with open(self.test_obj["alert_channel_file"], 'r') as file:
             data = json.load(file)
+        data["channel"]["name"] = "user_alert_channels_" + TestUtil.random_string()
         created_alert_channel_response = self.backend.create_alert_channel(data)
         assert created_alert_channel_response, "Expected alert channel"
         guid = created_alert_channel_response.json()["channel"]["guid"]


### PR DESCRIPTION
## **User description**
Signed-off-by: refaelm <refaelm@armosec.io>


___

## **Type**
enhancement, tests


___

## **Description**
- The alert channel creation test in `alert_channels.py` now uses a random name for each test execution, enhancing test reliability by avoiding potential conflicts with existing data.
- This change involves importing `TestUtil` for generating random strings and modifying the JSON data structure used in the alert channel creation.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alert_channels.py</strong><dd><code>Enhance Alert Channel Test with Random Name Generation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/users_notifications/alert_channels.py
<li>Imported <code>TestUtil</code> from <code>systest_utils</code>.<br> <li> Modified the alert channel creation process to use a random name for <br>the channel.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/343/files#diff-92e6154bcdfe703d026feedb1953e000318b7c16c792975fadc60ddb723f8458">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

