### PR TITLE
Support dns backwards compatibility

### DIFF
--- a/tests_scripts/helm/base_network_policy.py
+++ b/tests_scripts/helm/base_network_policy.py
@@ -101,7 +101,16 @@ class BaseNetworkPolicy(BaseHelm):
         for expected_entry in expected_entries:
             # if expected entry contains dns, that means we explicitly expect a DNS entry,
             # we don't care about the IP address
-            if expected_entry["dns"] != "": 
+            if expected_entry["dns"] != "":
+
+                # add '.' to the DNS (this is for backwards compatibility)
+                if not expected_entry["dns"].endswith('.'):
+                    expected_entry["dns"] += "."
+                for actual_entry in actual_entries:
+                    if not actual_entry["dns"].endswith('.'):
+                        actual_entry["dns"] += "."
+
+                # compare DNS
                 actual_entry = next((actual_entry for actual_entry in actual_entries if expected_entry["dns"] == actual_entry["dns"]), None)
                 assert actual_entry, f"expected a network neighbor entry with DNS: {expected_entry['dns']} not found in actual entries {actual_entries}"
                 assert expected_entry["type"] == actual_entry["type"], f"expected type: {expected_entry['type']} not found in actual type {actual_entry['type']}"


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced DNS handling in `validate_network_neighbor_entry` to append a '.' at the end of DNS entries if not present, ensuring backwards compatibility.
- Adjusted DNS comparison logic to accommodate the format change, improving the robustness of network policy validation.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_network_policy.py</strong><dd><code>Enhance DNS Backwards Compatibility in Network Policy Validation</code></dd></summary>
<hr>

tests_scripts/helm/base_network_policy.py
<li>Added logic to ensure DNS entries end with a '.' for backwards <br>compatibility.<br> <li> Modified the DNS comparison to include the new format adjustment.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/344/files#diff-35ac8c7feff5887b6f1a5260b2f73fa151cda6cc9f28e4024ec718c54a82a0f7">+10/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

