### PR TITLE
Increase timeout for waiting for response from BE in AttackChainsScen…

### DIFF
--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -118,7 +118,7 @@ class AttackChainsScenarioManager(ScenarioManager):
         Logger.logger.info("wait for response from BE")
         r, t = self.wait_for_report(
             self.backend.get_active_attack_chains, 
-            timeout=180,
+            timeout=600,
             current_datetime=current_datetime,
             cluster_name=self.cluster
             )


### PR DESCRIPTION
### **User description**
…arioManager


___

### **PR Type**
enhancement


___

### **Description**
- Increased the timeout parameter in the `wait_for_report` method call within `verify_scenario` from 180 seconds to 600 seconds to allow more time for receiving responses from the backend.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scenarios_manager.py</strong><dd><code>Increase Backend Response Timeout in Scenario Manager</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

systest_utils/scenarios_manager.py
<li>Increased the timeout for waiting for a response from the backend in <br><code>verify_scenario</code> method from 180 seconds to 600 seconds.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/345/files#diff-45b40c85bafc6685da4f909cffb6852947ec4525688eb921c8f1f1ac5b4da638">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

