### PR TITLE
chore: Fix sleep duration for triggering scan in helm tests

### DIFF
--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -53,7 +53,12 @@ class ScanStatusWithKubescapeHelmChart(BaseHelm, BaseKubescape):
 
         Logger.logger.info("2.2 verify installation")
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME)
-        time.sleep(10)
+
+        # TODO: fix the case on which the scan result is logged and triggers security risks before all kubernetes objects are created on backend.
+        # meanwhile, sleeping to allow all kubernetes objects to be created on backend and triggering scan.
+        time.sleep(20)
+        scenarios_manager.trigger_scan(self.test_obj["test_job"][0]["trigger_by"],
+                                       additional_params={"triggeredFrom": "securityRiskPage"})
 
         Logger.logger.info("3. Verify scenario on backend")
         scenarios_manager.verify_scenario()
@@ -130,6 +135,11 @@ class ScanSecurityRisksWithKubescapeHelmChart(BaseHelm, BaseKubescape):
 
         Logger.logger.info("2.2 verify installation")
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME)
+
+        # TODO: fix the case on which the scan result is logged and triggers security risks before all kubernetes objects are created on backend.
+        # meanwhile, sleeping to allow all kubernetes objects to be created on backend and triggering scan.
+        time.sleep(20)
+        scenarios_manager.trigger_scan(self.test_obj["test_job"][0]["trigger_by"])
 
         Logger.logger.info("3. Verify scenario on backend")
         result = scenarios_manager.verify_scenario()
@@ -218,6 +228,11 @@ class ScanSecurityRisksExceptionsWithKubescapeHelmChart(BaseHelm, BaseKubescape)
 
         Logger.logger.info("2.2 verify installation")
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME)
+
+        # TODO: fix the case on which the scan result is logged and triggers security risks before all kubernetes objects are created on backend.
+        # meanwhile, sleeping to allow all kubernetes objects to be created on backend and triggering scan.
+        time.sleep(20)
+        scenarios_manager.trigger_scan(self.test_obj["test_job"][0]["trigger_by"])
 
         Logger.logger.info("3. Verify scenario on backend")
         result = scenarios_manager.verify_scenario()


### PR DESCRIPTION
### **PR Type**
enhancement, bug_fix


___

### **Description**
- Increased the sleep duration from 10 to 20 seconds in multiple test scenarios within `ks_microservice.py` to allow for complete creation of Kubernetes objects before scans.
- Introduced scan triggers immediately following the increased sleep duration to ensure timely detection of security risks.
- These changes aim to enhance the reliability and accuracy of security scans in Helm test scripts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Enhance Stability of Helm Tests by Adjusting Sleep and Adding Scan </code><br><code>Triggers</code></dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py
<li>Increased sleep duration from 10 to 20 seconds in three different <br>sections to ensure all Kubernetes objects are created before <br>triggering scans.<br> <li> Added a scan trigger after the increased sleep duration in each <br>section.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/354/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+16/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

