### PR TITLE
chore: Fix sleep duration for triggering scan in helm tests

### DIFF
--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -229,11 +229,6 @@ class ScanSecurityRisksExceptionsWithKubescapeHelmChart(BaseHelm, BaseKubescape)
         Logger.logger.info("2.2 verify installation")
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME)
 
-        # TODO: fix the case on which the scan result is logged and triggers security risks before all kubernetes objects are created on backend.
-        # meanwhile, sleeping to allow all kubernetes objects to be created on backend and triggering scan.
-        time.sleep(20)
-        scenarios_manager.trigger_scan(self.test_obj["test_job"][0]["trigger_by"])
-
         Logger.logger.info("3. Verify scenario on backend")
         result = scenarios_manager.verify_scenario()
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed a hardcoded sleep delay and a manual scan trigger in the Helm test script for `ks_microservice.py`.
- This change streamlines the test execution by relying on the natural flow of the system to trigger necessary scans, improving the efficiency and reliability of the tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Enhance Test Setup by Removing Forced Delays and Scans</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py
<li>Removed sleep delay and direct scan trigger in the test setup process.<br> <li> Enhanced the test flow by relying on automated triggers for scans.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/356/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

