### PR TITLE
fix related resources check

### DIFF
--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -159,8 +159,9 @@ class AttackChainsScenarioManager(ScenarioManager):
         """
         # check at first if we are managin dictionaries
         if isinstance(obj1, dict) and isinstance(obj2, dict):
-            if 'relatedResources' in obj1 and 'relatedResources' in obj2:
-                if obj1['relatedResources'] != obj2['relatedResources']:
+            if 'relatedResources' in obj1 and 'relatedResources' in obj2 and obj1['relatedResources'] != None and obj2['relatedResources'] != None and obj1['relatedResources'] != "None" and obj2['relatedResources'] != "None":
+                if len(obj1['relatedResources']) != len(obj2['relatedResources']):
+                    Logger.logger.error(f"Length mismatch: result: {len(obj1['relatedResources'])} != expected: {len(obj2['relatedResources'])}")
                     return False
             # check if key 'nextNodes' is present in the dictionaries
             if 'nextNodes' in obj1 and 'nextNodes' in obj2:


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Improved the validation for 'relatedResources' in `compare_nodes` method to ensure that neither dictionary has 'relatedResources' set to None or "None".
- Added error logging to report a mismatch in the length of 'relatedResources' arrays, aiding in debugging.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scenarios_manager.py</strong><dd><code>Improve 'relatedResources' Validation and Error Logging</code>&nbsp; &nbsp; </dd></summary>
<hr>

systest_utils/scenarios_manager.py
<li>Enhanced the check for 'relatedResources' to ensure neither is None or <br>the string "None".<br> <li> Added a log error message when the lengths of 'relatedResources' do <br>not match.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/363/files#diff-45b40c85bafc6685da4f909cffb6852947ec4525688eb921c8f1f1ac5b4da638">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

