### PR TITLE
fix scenario to create only 1 a.c

### DIFF
--- a/configurations/scenarios-test-env/attack-chain-8/01-exposed-dp.yaml
+++ b/configurations/scenarios-test-env/attack-chain-8/01-exposed-dp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: nginx
+    app: alpine
   ports:
     - protocol: TCP
       port: 80
@@ -20,24 +20,23 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: alpine-deployment
   labels:
-    app: nginx
+    app: alpine
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: nginx
+      app: alpine
   template:
     metadata:
       labels:
-        app: nginx
+        app: alpine
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.14.2
-        ports:
-        - containerPort: 80
+      - name: alpine
+        image: alpine:latest
+        command: ["sh", "-c", "echo Hello Kubernetes! && sleep 3600"]
         resources:
           requests:
             cpu: 700m

--- a/configurations/scenarios-test-env/attack-chain-8/README.md
+++ b/configurations/scenarios-test-env/attack-chain-8/README.md
@@ -12,7 +12,7 @@ Create the cluster with **kind** using the provided configuration file:
 kind create cluster --config kind-config --name attack-chains
 ```
 
-Install **mysql** and **nginx** with their manifests:
+Install **mysql** and **alpine** with their manifests:
 
 ```shell
 kubectl apply -f 01-exposed-dp.yaml
@@ -24,5 +24,5 @@ kubectl apply -f 02-rbac-permissions.yaml
 After creating the cluster and installing the manifests you should be able to see attack chain composed like so:
 
 * **Initial Access**: through a `LoadBalancer` service.
-* **Cluster Access**: with **nginx** `Deployment` cluster takeover roles.
+* **Cluster Access**: with **alpine** `Deployment` cluster takeover roles.
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated Kubernetes service and deployment configurations to use `alpine` instead of `nginx`, including changing the container image and command.
- Modified README documentation to align with the changes in Kubernetes configurations, replacing references from `nginx` to `alpine`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>01-exposed-dp.yaml</strong><dd><code>Update Kubernetes Configurations to Use Alpine Instead of Nginx</code></dd></summary>
<hr>

configurations/scenarios-test-env/attack-chain-8/01-exposed-dp.yaml
<li>Changed application from <code>nginx</code> to <code>alpine</code> in the service and deployment <br>configurations.<br> <li> Updated container configuration to use <code>alpine:latest</code> and run a <br>specific command.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/364/files#diff-19758641b4b0872964ed02f50767490aceaa28c0bf7303670f4de0f20eee2242">+9/-10</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to Reflect Alpine Usage in Kubernetes Setup</code></dd></summary>
<hr>

configurations/scenarios-test-env/attack-chain-8/README.md
<li>Updated documentation to reflect the change from <code>nginx</code> to <code>alpine</code> in <br>the Kubernetes setup instructions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/364/files#diff-3e4fa4ccc28a6f4cfe6df406d488d8bf53c78f6b38f00d6f91d6af3ea40cb8e6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

