### PR TITLE
Create test workload before installing helm

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -992,7 +992,7 @@ class ControlPanelAPI(object):
                       json=body)
         if not 200 <= r.status_code < 300:
             raise Exception(
-                'Error accessing dashboard. Request: results of posture controls "%s" (code: %d, message: %s)' % (
+                'Error accessing dashboard. Request: results of posture clusters "%s" (code: %d, message: %s)' % (
                     self.customer, r.status_code, r.text))
         if len(r.json()['response']) == 0:
             raise Exception('Error accessing dashboard. Request: results of posture controls is empty')

--- a/tests_scripts/helm/jira_integration.py
+++ b/tests_scripts/helm/jira_integration.py
@@ -121,12 +121,12 @@ class JiraIntegration(BaseKubescape, BaseHelm):
             namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360
         )       
 
-        Logger.logger.info(f"Trigger a scan")
-        self.backend.trigger_posture_scan(
-            cluster_name=cluster,
-            framework_list=["AllControls"],
-            with_host_sensor="false",
-        )
+        # Logger.logger.info(f"Trigger a scan")
+        # self.backend.trigger_posture_scan(
+        #     cluster_name=cluster,
+        #     framework_list=["AllControls"],
+        #     with_host_sensor="false",
+        # )
 
         Logger.logger.info(f"Get report guid")
         report_guid = self.get_report_guid(

--- a/tests_scripts/helm/jira_integration.py
+++ b/tests_scripts/helm/jira_integration.py
@@ -120,14 +120,7 @@ class JiraIntegration(BaseKubescape, BaseHelm):
         self.verify_running_pods(
             namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360
         )       
-
-        # Logger.logger.info(f"Trigger a scan")
-        # self.backend.trigger_posture_scan(
-        #     cluster_name=cluster,
-        #     framework_list=["AllControls"],
-        #     with_host_sensor="false",
-        # )
-
+        
         Logger.logger.info(f"Get report guid")
         report_guid = self.get_report_guid(
             cluster_name=cluster, wait_to_result=True, framework_name="AllControls"

--- a/tests_scripts/helm/jira_integration.py
+++ b/tests_scripts/helm/jira_integration.py
@@ -106,13 +106,6 @@ class JiraIntegration(BaseKubescape, BaseHelm):
         cluster, namespace = self.setup(apply_services=False)
         print("Debug: cluster: ", cluster)
 
-        Logger.logger.info(f"Install Helm Chart")
-        self.add_and_upgrade_armo_to_repo()
-        self.install_armo_helm_chart(helm_kwargs=self.helm_kwargs)
-        self.verify_running_pods(
-            namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360
-        )
-
         Logger.logger.info(f"Apply workload")
         workload = self.apply_yaml_file(
             yaml_file=self.test_obj["workload"], namespace=namespace
@@ -120,6 +113,13 @@ class JiraIntegration(BaseKubescape, BaseHelm):
         self.verify_all_pods_are_running(
             namespace=namespace, workload=workload, timeout=300
         )
+
+        Logger.logger.info(f"Install Helm Chart")
+        self.add_and_upgrade_armo_to_repo()
+        self.install_armo_helm_chart(helm_kwargs=self.helm_kwargs)
+        self.verify_running_pods(
+            namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360
+        )       
 
         Logger.logger.info(f"Trigger a scan")
         self.backend.trigger_posture_scan(


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Reordered the installation of the Helm chart to occur after applying the workload in the `setup_cluster_and_run_posture_scan` method.
- Added debug print statements for better traceability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_integration.py</strong><dd><code>Reorder Helm chart installation after workload application.</code></dd></summary>
<hr>

tests_scripts/helm/jira_integration.py
<li>Reordered the installation of the Helm chart to occur after applying <br>the workload.<br> <li> Added debug print statements for better traceability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/368/files#diff-5a901f2fef79a9c4f309e5fe5da5f599737904ffbe50627fc852419377b5b64a">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

