### PR TITLE
wait for status to be updated to done before triggering another scan

### DIFF
--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -62,6 +62,8 @@ class ScanStatusWithKubescapeHelmChart(BaseHelm, BaseKubescape):
         Logger.logger.info("3. Verify scenario on backend")
         scenarios_manager.verify_scenario()
 
+        # wait for status to be updated to done before triggering another scan
+        time.sleep(5)
         Logger.logger.info("4. trigger posture scan")
         time_before_scan = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         scenarios_manager.trigger_scan(self.test_obj["test_job"][0]["trigger_by"],


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a 5-second delay before triggering another scan to ensure the status is updated to 'done'.
- Enhances the reliability of the scan triggering process.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Add delay to ensure status update before scan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py
<li>Added a sleep of 5 seconds before triggering another scan.<br> <li> Ensures status is updated to 'done' before proceeding.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/369/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

