### PR TITLE
fix: Add delay before triggering scan in ScanSecurityRisksExceptionsW…

### DIFF
--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -230,6 +230,11 @@ class ScanSecurityRisksExceptionsWithKubescapeHelmChart(BaseHelm, BaseKubescape)
         Logger.logger.info("2.2 verify installation")
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME)
 
+        # TODO: fix the case on which the scan result is logged and triggers security risks before all kubernetes objects are created on backend.
+        # meanwhile, sleeping to allow all kubernetes objects to be created on backend and triggering scan.
+        time.sleep(20)
+        scenarios_manager.trigger_scan(self.test_obj["test_job"][0]["trigger_by"])
+
         Logger.logger.info("3. Verify scenario on backend")
         result = scenarios_manager.verify_scenario()
 


### PR DESCRIPTION
### **User description**
…ithKubescapeHelmChart

To fix the issue where the scan result is logged and triggers security risks before all Kubernetes objects are created on the backend, a delay of 20 seconds is added before triggering the scan. This allows all Kubernetes objects to be created on the backend before the scan is triggered.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a 20-second delay before triggering the scan in `ScanSecurityRisksExceptionsWithKubescapeHelmChart` to ensure all Kubernetes objects are created on the backend.
- This change prevents premature logging and triggering of security risks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Add delay before triggering scan to ensure backend readiness</code></dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py
<li>Added a 20-second delay before triggering the scan.<br> <li> Ensured all Kubernetes objects are created on the backend before the <br>scan.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/372/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

