### PR TITLE
added a sleep and additional logs for the np test

### DIFF
--- a/tests_scripts/helm/base_network_policy.py
+++ b/tests_scripts/helm/base_network_policy.py
@@ -59,6 +59,10 @@ class BaseNetworkPolicy(BaseHelm):
             if TestUtil.get_arg_from_dict(self.test_driver.kwargs, statics.CREATE_TEST_FIRST_TIME_RESULTS, False):
                 self.store_netwrok_for_first_time_results(result_data=actual_network_neighbors, store_path=self.test_obj["expected_network_neighbors"])
                 continue
+
+            if actual_network_neighbors:
+                nn_json = json.dumps(actual_network_neighbors)
+                Logger.logger.info(f"Actual Network Neighbor (name: {expected_network_neighbors['metadata']['name']}): {nn_json}")
             self.validate_expected_network_neighbors(actual_network_neighbors=actual_network_neighbors, expected_network_neighbors=expected_network_neighbors, namespace=namespace)
 
 

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -216,6 +216,8 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         self.add_and_upgrade_armo_to_repo()
         self.install_armo_helm_chart(helm_kwargs=helm_kwargs)
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=360)
+        
+        TestUtil.sleep(30, "wait for 30 seconds before restarting pods", "info")
 
         pods_list = list(map(lambda obj: obj['metadata']['name'], workload_objs))
         Logger.logger.info(f"3. Restarting pods: {pods_list}")


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Added logging for actual network neighbors in `validate_expected_network_neighbors_list` method.
- Introduced JSON serialization for network neighbor data for better readability in logs.
- Added a sleep of 30 seconds before restarting pods to ensure stability.
- Included a log message indicating the sleep action.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_network_policy.py</strong><dd><code>Add logging for network neighbors in validation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/base_network_policy.py
<li>Added logging for actual network neighbors.<br> <li> Introduced JSON serialization for network neighbor data.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/381/files#diff-35ac8c7feff5887b6f1a5260b2f73fa151cda6cc9f28e4024ec718c54a82a0f7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_policy.py</strong><dd><code>Add sleep and logging before restarting pods.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/network_policy.py
<li>Added a sleep of 30 seconds before restarting pods.<br> <li> Included a log message for the sleep action.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/381/files#diff-83e690ba62dd64c5e40792cf88ae5cb24ecb8ffeeab4cf257e4dcb661bd9b3c0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

