### PR TITLE
Remove deprecated calls

### DIFF
--- a/tests_scripts/helm/base_vuln_scan.py
+++ b/tests_scripts/helm/base_vuln_scan.py
@@ -696,13 +696,6 @@ class BaseVulnerabilityScanning(BaseHelm):
                                      expect_to_results=False)
         assert not cj, f"Failed to verify from backend the cronjob was deleted, cronjob: {cj}"
 
-    def test_delete_registry_scan_cronjob_deprecated(self, cron_job: dict):
-        self.backend.delete_registry_scan_cronjob_deprecated(cj=cron_job)
-        TestUtil.sleep(30, "wait till delete cronjob will arrive to backend")
-        cj, t = self.wait_for_report(report_type=self.backend.get_registry_scan_cronjob, cj_name=cron_job['name'],
-                                     expect_to_results=False)
-        assert not cj, f"Failed to verify from backend the cronjob was deleted, cronjob: {cj}"
-
     def test_update_vuln_scan_cronjob(self, cron_job: dict, schedule_string: str):
         cron_job[statics.CA_VULN_SCAN_CRONJOB_CRONTABSCHEDULE_FILED] = schedule_string
         self.backend.update_vuln_scan_cronjob(cj=cron_job)
@@ -760,19 +753,6 @@ class BaseVulnerabilityScanning(BaseHelm):
 
         return new_cj
 
-    def test_update_registry_scan_cronjob_deprecated(self, cron_job: dict, schedule_string: str):
-        cron_job[statics.CA_VULN_SCAN_CRONJOB_CRONTABSCHEDULE_FILED] = schedule_string
-        self.backend.update_registry_scan_cronjob_deprecated(cj=cron_job)
-        TestUtil.sleep(30, "wait till update cronjob will arrive to backend")
-
-        new_cj, t = self.wait_for_report(report_type=self.backend.get_registry_scan_cronjob, cj_name=cron_job['name'])
-        assert new_cj[statics.CA_VULN_SCAN_CRONJOB_CRONTABSCHEDULE_FILED] == schedule_string, \
-            f'Failed to verify that cronjob {cron_job["name"]} with schedule {schedule_string} was updated. ' \
-            f'cronjob: {new_cj}'
-        assert (new_cj[statics.CA_VULN_SCAN_CRONJOB_NAME_FILED].startswith("kubescape-registry-scan")), \
-            f'cronjob {cron_job["name"]} has wrong name for {statics.CA_VULN_SCAN_CRONJOB_NAME_FILED}. '
-        return new_cj
-
     def test_create_vuln_scan_cronjob(self, namespaces_list: list, schedule_string: str):
         old_expected_cjs = self.kubernetes_obj.get_vuln_scan_cronjob()
         old_actual_cjs, t = self.wait_for_report(report_type=self.backend.get_vuln_scan_cronjob_list,
@@ -784,28 +764,6 @@ class BaseVulnerabilityScanning(BaseHelm):
         TestUtil.sleep(30, "wait till cronjob will arrive to backend")
         new_expected_cjs = self.kubernetes_obj.get_vuln_scan_cronjob()
         new_actual_cjs, t = self.wait_for_report(report_type=self.backend.get_vuln_scan_cronjob_list,
-                                                 expected_cjs=new_expected_cjs,
-                                                 cluster_name=self.kubernetes_obj.get_cluster_name())
-
-        new_cj = self.get_new_cronjob(old_cronjob_list=old_actual_cjs, new_cronjob_list=new_actual_cjs)
-        assert new_cj, f"Failed to find the new cronjob, old_cronjob_list: {old_actual_cjs}. " \
-                       f"new_cronjob_list: {new_actual_cjs}"
-
-        return new_cj
-
-    def test_create_registry_scan_cronjob_deprecated(self, registry_name: str, schedule_string: str):
-        old_expected_cjs = self.kubernetes_obj.get_registry_scan_cronjob()
-        old_actual_cjs, t = self.wait_for_report(report_type=self.backend.get_registry_scan_cronjob_list,
-                                                 expected_cjs=old_expected_cjs,
-                                                 cluster_name=self.kubernetes_obj.get_cluster_name())
-
-        resp = self.backend.create_registry_scan_job_request_deprecated(
-            cluster_name=self.kubernetes_obj.get_cluster_name(),
-            schedule_string=schedule_string, registry_name=registry_name)
-
-        TestUtil.sleep(30, "wait till cronjob will arrive to backend")
-        new_expected_cjs = self.kubernetes_obj.get_registry_scan_cronjob()
-        new_actual_cjs, t = self.wait_for_report(report_type=self.backend.get_registry_scan_cronjob_list,
                                                  expected_cjs=new_expected_cjs,
                                                  cluster_name=self.kubernetes_obj.get_cluster_name())
 

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -453,6 +453,8 @@ class ScanWithKubescapeAsServiceTest(BaseHelm, BaseKubescape):
         self.add_and_upgrade_armo_to_repo()
         # 2.2 install armo helm-chart
         self.install_armo_helm_chart()
+        # 1.3 verify installation
+        self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=240)
 
         self.test_scan_jobs(port=statics.KS_PORT_FORWARD)
 

--- a/tests_scripts/helm/vuln_scan.py
+++ b/tests_scripts/helm/vuln_scan.py
@@ -796,18 +796,6 @@ class RegistryScanningTriggeringWithCronJob(VulnerabilityScanningRegistry):
         Logger.logger.info("Test delete registry-scan cronjob ")
         self.test_delete_registry_scan_cronjob(cron_job=cj, credentials=new_auth)
 
-        Logger.logger.info("Test create registry-scan cronjob - deprecated API")
-        cj = self.test_create_registry_scan_cronjob_deprecated(registry_name=registry,
-                                                               schedule_string=self.test_obj.get_arg("schedule_time"))
-
-        Logger.logger.info("Test update registry-scan cronjob - deprecated API")
-        cj = self.test_update_registry_scan_cronjob_deprecated(cron_job=cj,
-                                                               schedule_string=self.test_obj.get_arg(
-                                                                   "updating_schedule_time"))
-
-        Logger.logger.info("Test delete registry-scan cronjob - deprecated API")
-        self.test_delete_registry_scan_cronjob_deprecated(cron_job=cj)
-
         return self.cleanup()
 
 


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Removed deprecated API calls for creating, updating, and deleting registry-scan cronjobs in `tests_scripts/helm/vuln_scan.py`.
- Simplified the `start` method by eliminating deprecated functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vuln_scan.py</strong><dd><code>Remove deprecated registry-scan cronjob API calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/vuln_scan.py
<li>Removed deprecated API calls for creating, updating, and deleting <br>registry-scan cronjobs.<br> <li> Simplified the <code>start</code> method by eliminating deprecated functionality.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/384/files#diff-288de96b50f4d3d32f61bc4d91633848bd020741853e6416e73f7c9a1ee415e0">+0/-12</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

