### PR TITLE
adding timeout fix

### DIFF
--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -52,7 +52,7 @@ class NetworkPolicy(BaseNetworkPolicy):
         self.run_exec_cmd(namespace=namespace, pod_name=pod_name, cmd="curl https://wikipedia.org", repeat=10)
 
         update_period_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_UPDATE_PERIOD][:-1]
-        TestUtil.sleep(5 * int(update_period_in_seconds), "wait for node-agent update period", "info")
+        TestUtil.sleep(6 * int(update_period_in_seconds), "wait for node-agent update period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files(
             self.test_obj["expected_network_neighbors"])
@@ -228,7 +228,7 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         Logger.logger.info(f"restarted pods successfully")
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(6 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files(
             self.test_obj["expected_network_neighbors"])


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Increased the sleep duration for the node-agent update period to ensure proper timing.
- Increased the sleep duration for the node-agent learning period to ensure proper timing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_policy.py</strong><dd><code>Increase sleep duration for node-agent periods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/network_policy.py
<li>Increased sleep duration for node-agent update period from 5 to 6 <br>times the update period.<br> <li> Increased sleep duration for node-agent learning period from 5 to 6 <br>times the learning period.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/387/files#diff-83e690ba62dd64c5e40792cf88ae5cb24ecb8ffeeab4cf257e4dcb661bd9b3c0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

