### PR TITLE
add mroe time

### DIFF
--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -228,7 +228,7 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         Logger.logger.info(f"restarted pods successfully")
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(6 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(7 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files(
             self.test_obj["expected_network_neighbors"])


### PR DESCRIPTION
### **PR Type**
tests


___

### **Description**
- Increased the sleep duration multiplier from 6 to 7 in the `start` method of `tests_scripts/helm/network_policy.py` to allow more time for the node-agent learning period.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_policy.py</strong><dd><code>Adjust sleep duration multiplier in `start` method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/network_policy.py
- Increased sleep duration multiplier from 6 to 7 in `start` method.



</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/388/files#diff-83e690ba62dd64c5e40792cf88ae5cb24ecb8ffeeab4cf257e4dcb661bd9b3c0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

