### PR TITLE
sr timeout fix + NP fixes

### DIFF
--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -139,7 +139,7 @@ class ScanSecurityRisksWithKubescapeHelmChart(BaseHelm, BaseKubescape):
 
         # TODO: fix the case on which the scan result is logged and triggers security risks before all kubernetes objects are created on backend.
         # meanwhile, sleeping to allow all kubernetes objects to be created on backend and triggering scan.
-        time.sleep(20)
+        time.sleep(60)
         scenarios_manager.trigger_scan(self.test_obj["test_job"][0]["trigger_by"])
 
         Logger.logger.info("3. Verify scenario on backend")

--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -42,7 +42,7 @@ class NetworkPolicy(BaseNetworkPolicy):
         self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(7 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         pod = self.wait_for_report(report_type=self.get_pod_if_ready, namespace=namespace, name="wikijs", timeout=180)
         pod_name = pod[0].metadata.name
@@ -130,7 +130,7 @@ class NetworkPolicyDataAppended(BaseNetworkPolicy):
         self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=180)
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(5 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(6 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files(
             self.test_obj["expected_network_neighbors"])
@@ -228,7 +228,7 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         Logger.logger.info(f"restarted pods successfully")
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(7 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(8 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files(
             self.test_obj["expected_network_neighbors"])


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Increased sleep duration in `ks_microservice.py` from 20 to 60 seconds to ensure all Kubernetes objects are created on the backend before triggering a scan.
- Adjusted sleep durations in `network_policy.py` for the node-agent learning period:
  - Increased from 5 to 7 times the duration in one section.
  - Increased from 5 to 6 times the duration in another section.
  - Increased from 7 to 8 times the duration in a third section.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Increase sleep duration for Kubernetes object creation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py
<li>Increased sleep duration from 20 to 60 seconds to allow all Kubernetes <br>objects to be created on the backend before triggering a scan.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/389/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_policy.py</strong><dd><code>Adjust sleep durations for node-agent learning period</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/network_policy.py
<li>Adjusted sleep durations for node-agent learning period in three <br>different sections.<br> <li> Increased sleep duration multipliers from 5 to 7, 5 to 6, and 7 to 8 <br>respectively.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/389/files#diff-83e690ba62dd64c5e40792cf88ae5cb24ecb8ffeeab4cf257e4dcb661bd9b3c0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

