### PR TITLE
np pod restarted - morefixes

### DIFF
--- a/tests_scripts/helm/network_policy.py
+++ b/tests_scripts/helm/network_policy.py
@@ -228,7 +228,7 @@ class NetworkPolicyPodRestarted(BaseNetworkPolicy):
         Logger.logger.info(f"restarted pods successfully")
 
         duration_in_seconds = helm_kwargs[statics.HELM_NODE_AGENT_LEARNING_PERIOD][:-1]
-        TestUtil.sleep(8 * int(duration_in_seconds), "wait for node-agent learning period", "info")
+        TestUtil.sleep(10 * int(duration_in_seconds), "wait for node-agent learning period", "info")
 
         expected_network_neighbors_list = TestUtil.load_objs_from_json_files(
             self.test_obj["expected_network_neighbors"])


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Increased the sleep duration multiplier from 8 to 10 in `tests_scripts/helm/network_policy.py` to allow more time for the node-agent learning period.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_policy.py</strong><dd><code>Adjust sleep duration for node-agent learning period</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/network_policy.py
<li>Increased the sleep duration multiplier from 8 to 10 for node-agent <br>learning period.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/391/files#diff-83e690ba62dd64c5e40792cf88ae5cb24ecb8ffeeab4cf257e4dcb661bd9b3c0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

