### PR TITLE
fix test

### DIFF
--- a/tests_scripts/helm/vuln_scan.py
+++ b/tests_scripts/helm/vuln_scan.py
@@ -940,7 +940,8 @@ class VulnerabilityV2Views(BaseVulnerabilityScanning):
         image = image[0]
         image_excluded_paths = {"root['lastScanTime']", "root['customerGUID']", "root['digest']",
                                 "root['repository']", "root['registry']", "root['namespaces']", "root['clusters']",
-                                "root['architecture']", "root['os']", "root['size'], root['baseImage']",}
+                                "root['architecture']", "root['os']", "root['size'], root['baseImage']"
+                                "root['clustersCount']", "root['namespacesCount']", "root['workloadsCount']"}
         if updateExpected:
             TestUtil.save_expceted_json(image, "configurations/expected-result/V2_VIEWS/image_details.json")
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a syntax issue in the `image_excluded_paths` set definition in the `vuln_scan.py` script.
- Added new keys (`root['clustersCount']`, `root['namespacesCount']`, `root['workloadsCount']`) to the `image_excluded_paths` set to enhance the test coverage.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vuln_scan.py</strong><dd><code>Fix and enhance test for vulnerability scan script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests_scripts/helm/vuln_scan.py

<li>Added new keys to <code>image_excluded_paths</code> set.<br> <li> Fixed syntax issue in the <code>image_excluded_paths</code> set definition.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/400/files#diff-288de96b50f4d3d32f61bc4d91633848bd020741853e6416e73f7c9a1ee415e0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

