### PR TITLE
Fix Jira schema to remove unused "Reporter" field

### DIFF
--- a/configurations/expected-result/integrations/expectedJiraSchema.json
+++ b/configurations/expected-result/integrations/expectedJiraSchema.json
@@ -1,6 +1,6 @@
 {
     "total": {
-        "value": 14,
+        "value": 13,
         "relation": "eq"
     },
     "response": [
@@ -128,14 +128,6 @@
             "fieldId": "labels",
             "type": "array",
             "items": "string",
-            "topValues": null,
-            "searchable": true
-        },
-        {
-            "required": false,
-            "name": "Reporter",
-            "fieldId": "reporter",
-            "type": "user",
             "topValues": null,
             "searchable": true
         },

--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -2244,9 +2244,9 @@ class ControlPanelAPI(object):
 
     def post_list_request(self, url, body: dict, expected_results: int = 0, params: dict = None):
         if params is None:
-            params = {"customerGUID": self.customer_guid}
+            params = {"customerGUID": self.selected_tenant_id}
         else:
-            params["customerGUID"] = self.customer_guid
+            params["customerGUID"] = self.selected_tenant_id
         r = self.post(url + "/list", params=params,
                       json=body)
         if not 200 <= r.status_code < 300:

--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -361,7 +361,7 @@ class SecurityRisksScenarioManager(ScenarioManager):
         """
         r = self.backend.get_security_risks_resources(self.cluster, self.namespace, security_risk_id)
         response = json.loads(r.text)
-        if response["response"] ==  None:
+        if "response" not in response or response["response"] ==  None:
             response["response"] = []
         return response
     

--- a/tests_scripts/helm/jira_integration.py
+++ b/tests_scripts/helm/jira_integration.py
@@ -62,7 +62,7 @@ class JiraIntegration(BaseKubescape, BaseHelm):
         assert jiraStatus, "Jira is missing form connection status"
         assert jiraStatus['status'] == "connected", "Jira is not connected"
 
-        Logger.logger.info('get cyberarmor-io site')       
+        Logger.logger.info('get cyberarmor-io site')   
         projectsResp = self.backend.search_jira_projects({})
         assert projectsResp, "Jira projects response is empty"
         site = next((site for site in projectsResp['availableSites'] if site['name'] == 'cyberarmor-io'), None)
@@ -100,7 +100,7 @@ class JiraIntegration(BaseKubescape, BaseHelm):
             field['topValues'] = None
                 
         #uncomment to update expected 
-        #TestUtil.save_expceted_json(schema, "configurations/expected-result/integrations/expectedJiraSchema.json")     
+        # TestUtil.save_expceted_json(schema, "configurations/expected-result/integrations/expectedJiraSchema_1.json")     
         TestUtil.compare_with_expected_file("configurations/expected-result/integrations/expectedJiraSchema.json", schema, {})
         #set site, project and issueType for the test
         self.site = site


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replaced `customer_guid` with `selected_tenant_id` in `post_list_request` method in `infrastructure/backend_api.py`.
- Added check for "response" key in `get_security_risks_resources` method in `systest_utils/scenarios_manager.py`.
- Minor formatting and comment updates in `setup_jira_config` method in `tests_scripts/helm/jira_integration.py`.
- Removed unused "Reporter" field from Jira schema and updated total value in `configurations/expected-result/integrations/expectedJiraSchema.json`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Update parameter key in `post_list_request` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
infrastructure/backend_api.py

<li>Replaced <code>customer_guid</code> with <code>selected_tenant_id</code> in <code>post_list_request</code> <br>method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/404/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expectedJiraSchema.json</strong><dd><code>Remove unused "Reporter" field from Jira schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
configurations/expected-result/integrations/expectedJiraSchema.json

<li>Removed "Reporter" field from Jira schema.<br> <li> Updated total value from 14 to 13.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/404/files#diff-41f632f012acfb7fb01109cff0bb2ef73f1ec62c7050f58f5d3305dd4f07e5be">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scenarios_manager.py</strong><dd><code>Improve response validation in `get_security_risks_resources` method</code></dd></summary>
<hr>
      
systest_utils/scenarios_manager.py

<li>Added check for "response" key in <code>get_security_risks_resources</code> method.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/404/files#diff-45b40c85bafc6685da4f909cffb6852947ec4525688eb921c8f1f1ac5b4da638">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_integration.py</strong><dd><code>Minor formatting and comment update in `setup_jira_config`</code></dd></summary>
<hr>
      
tests_scripts/helm/jira_integration.py

<li>Minor formatting changes in <code>setup_jira_config</code> method.<br> <li> Updated commented out file path for saving expected JSON.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/404/files#diff-5a901f2fef79a9c4f309e5fe5da5f599737904ffbe50627fc852419377b5b64a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

