### PR TITLE
remove extra hosts in deployment-wikijs-basic

### DIFF
--- a/configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
@@ -25,42 +25,6 @@
     "ingress": null,
     "egress": [
       {
-        "identifier": "5ad9341e6dde8c3207c811b3304d1e18601c56151f02dfeb6ec20f4f7b6dfb47",
-        "type": "external",
-        "dns": "wikipedia.org.",
-        "dnsNames": [
-          "wikipedia.org."
-        ],
-        "ports": [
-          {
-            "name": "TCP-443",
-            "protocol": "TCP",
-            "port": 443
-          }
-        ],
-        "podSelector": null,
-        "namespaceSelector": null,
-        "ipAddress": "185.15.58.224"
-      },
-      {
-        "identifier": "66c89b9fd8bd51e9c16c2eb568c64285e1bf89a98e5eb878c7cfb123246857a6",
-        "type": "external",
-        "dns": "google.com.",
-        "dnsNames": [
-          "google.com."
-        ],
-        "ports": [
-          {
-            "name": "TCP-443",
-            "protocol": "TCP",
-            "port": 443
-          }
-        ],
-        "podSelector": null,
-        "namespaceSelector": null,
-        "ipAddress": "142.250.179.78"
-      },
-      {
         "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",
         "type": "internal",
         "dns": "",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed unnecessary external hosts `wikipedia.org` and `google.com` from the egress list in the `deployment-wikijs-basic.json` configuration file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment-wikijs-basic.json</strong><dd><code>Remove extra external hosts from egress list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json

<li>Removed external hosts <code>wikipedia.org</code> and <code>google.com</code> from the egress <br>list.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/411/files#diff-8ba39b31d15de75e9b2aeb2b3edb9b8bf99eee7a594f747a3897a482ea33fbf1">+0/-36</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

