### PR TITLE
fix nil slices

### DIFF
--- a/configurations/network-policy/expected-generated-network-policy/deployment-wikijs-basic.json
+++ b/configurations/network-policy/expected-generated-network-policy/deployment-wikijs-basic.json
@@ -12,22 +12,7 @@
     "name": "deployment-wikijs",
     "namespace": "systest-ns-pjqm"
   },
-  "policyRef": [
-    {
-      "dns": "google.com.",
-      "ipBlock": "108.177.120.100/32",
-      "name": "",
-      "originalIP": "108.177.120.100",
-      "server": ""
-    },
-    {
-      "dns": "wikipedia.org.",
-      "ipBlock": "208.80.154.224/32",
-      "name": "",
-      "originalIP": "208.80.154.224",
-      "server": ""
-    }
-  ],
+  "policyRef": [],
   "spec": {
     "apiVersion": "networking.k8s.io/v1",
     "kind": "NetworkPolicy",
@@ -47,26 +32,6 @@
     },
     "spec": {
       "egress": [
-        {
-          "ports": [
-            {
-              "port": 443,
-              "protocol": "TCP"
-            }
-          ],
-          "to": [
-            {
-              "ipBlock": {
-                "cidr": "108.177.120.100/32"
-              }
-            },
-            {
-              "ipBlock": {
-                "cidr": "208.80.154.224/32"
-              }
-            }
-          ]
-        },
         {
           "ports": [
             {

--- a/configurations/network-policy/expected-network-neighbors/busybox-known-server.json
+++ b/configurations/network-policy/expected-network-neighbors/busybox-known-server.json
@@ -19,10 +19,6 @@
     }
   },
   "spec": {
-    "matchLabels": {
-      "app": "busybox"
-    },
-    "ingress": null,
     "egress": [
       {
         "identifier": "238053dc2e1cbe8820de562678e8cde84593e95d41e6f1a58bb987741f9e30a3",
@@ -82,6 +78,10 @@
         "namespaceSelector": null,
         "ipAddress": "142.250.179.68"
       }
-    ]
+    ],
+    "ingress": [],
+    "matchLabels": {
+      "app": "busybox"
+    }
   }
 }

--- a/configurations/network-policy/expected-network-neighbors/busybox.json
+++ b/configurations/network-policy/expected-network-neighbors/busybox.json
@@ -19,10 +19,6 @@
     }
   },
   "spec": {
-    "matchLabels": {
-      "app": "busybox"
-    },
-    "ingress": null,
     "egress": [
       {
         "identifier": "66c89b9fd8bd51e9c16c2eb568c64285e1bf89a98e5eb878c7cfb123246857a6",
@@ -84,6 +80,10 @@
         },
         "ipAddress": ""
       }
-    ]
+    ],
+    "ingress": [],
+    "matchLabels": {
+      "app": "busybox"
+    }
   }
 }

--- a/configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json
@@ -44,6 +44,6 @@
         "ipAddress": ""
       }
     ],
-    "egress": null
+    "egress": []
   }
 }

--- a/configurations/network-policy/expected-network-neighbors/deployment-mariadb.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-mariadb.json
@@ -19,9 +19,7 @@
     }
   },
   "spec": {
-    "matchLabels": {
-      "app": "mariadb"
-    },
+    "egress": [],
     "ingress": [
       {
         "identifier": "ee5c5b2f07834fa64174c3d2ad0505366e4b26777174906b91e83dcd163f8ec2",
@@ -44,6 +42,8 @@
         "ipAddress": ""
       }
     ],
-    "egress": null
+    "matchLabels": {
+      "app": "mariadb"
+    }
   }
 }

--- a/configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json
@@ -22,7 +22,7 @@
     "matchLabels": {
       "app": "nginx"
     },
-    "ingress": null,
+    "ingress": [],
     "egress": [
       {
         "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",

--- a/configurations/network-policy/expected-network-neighbors/deployment-nginx.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-nginx.json
@@ -19,10 +19,10 @@
     }
   },
   "spec": {
+    "egress": [],
+    "ingress": [],
     "matchLabels": {
       "app": "nginx"
-    },
-    "ingress": null,
-    "egress": null
+    }
   }
 }

--- a/configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json
@@ -22,7 +22,7 @@
     "matchLabels": {
       "app": "wikijs"
     },
-    "ingress": null,
+    "ingress": [],
     "egress": [
       {
         "identifier": "e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3",

--- a/configurations/network-policy/expected-network-neighbors/deployment-wikijs.json
+++ b/configurations/network-policy/expected-network-neighbors/deployment-wikijs.json
@@ -19,10 +19,6 @@
     }
   },
   "spec": {
-    "matchLabels": {
-      "app": "wikijs"
-    },
-    "ingress": null,
     "egress": [
       {
         "identifier": "5ad9341e6dde8c3207c811b3304d1e18601c56151f02dfeb6ec20f4f7b6dfb47",
@@ -104,6 +100,10 @@
         "namespaceSelector": null,
         "ipAddress": ""
       }
-    ]
+    ],
+    "ingress": [],
+    "matchLabels": {
+      "app": "wikijs"
+    }
   }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replaced `ingress` and `egress` null values with empty arrays in multiple network policy configurations.
- Removed specific `policyRef` entries and simplified `egress` rules in `deployment-wikijs-basic.json`.
- Reordered `matchLabels` to follow `ingress` in several network policy files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment-wikijs-basic.json</strong><dd><code>Fix nil slices in deployment-wikijs-basic network policy</code>&nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-generated-network-policy/deployment-wikijs-basic.json

<li>Removed specific <code>policyRef</code> entries and replaced with an empty array.<br> <li> Removed specific <code>egress</code> rules and replaced with a simplified <br>structure.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-d704dc24387e5ac0e8a8d632993cbe289c2228c42bbcc3973023d19febf46363">+1/-36</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>busybox-known-server.json</strong><dd><code>Fix nil slices in busybox-known-server network policy</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/busybox-known-server.json

<li>Replaced <code>ingress</code> null values with empty arrays.<br> <li> Reordered <code>matchLabels</code> to follow <code>ingress</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-aadd7c9f80a285598cfa101102f89a8269e6bdcac76ddb94c9b8370f7e6f08f3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>busybox.json</strong><dd><code>Fix nil slices in busybox network policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/busybox.json

<li>Replaced <code>ingress</code> null values with empty arrays.<br> <li> Reordered <code>matchLabels</code> to follow <code>ingress</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-4a0349c146a0853e8f5d4bcaea8f8030d2c405ea5a3eba07642500385233ff38">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-mariadb-basic.json</strong><dd><code>Fix nil slices in deployment-mariadb-basic network policy</code></dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-mariadb-basic.json

- Replaced `egress` null values with empty arrays.



</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-ac5ddd45032334cfc9db1e4dd1aff420be64c0ab94187cbc2acf40e68aa8766f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-mariadb.json</strong><dd><code>Fix nil slices in deployment-mariadb network policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-mariadb.json

<li>Replaced <code>egress</code> null values with empty arrays.<br> <li> Reordered <code>matchLabels</code> to follow <code>egress</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-938f9b2078b8a891c0bd8548c7478cc24958b23927b4d8c82786324a7559f4d6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-nginx-basic.json</strong><dd><code>Fix nil slices in deployment-nginx-basic network policy</code>&nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-nginx-basic.json

- Replaced `ingress` null values with empty arrays.



</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-bdb82161e6ba62307b9b4aeb861b70355e9b2ead703624fe3768e7c9a3a17609">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-nginx.json</strong><dd><code>Fix nil slices in deployment-nginx network policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-nginx.json

- Replaced `ingress` and `egress` null values with empty arrays.



</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-b68b269760135f469e65df3c86f0a89f136186f7e096962a93904064221a5bda">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-wikijs-basic.json</strong><dd><code>Fix nil slices in deployment-wikijs-basic network policy</code>&nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-wikijs-basic.json

- Replaced `ingress` null values with empty arrays.



</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-8ba39b31d15de75e9b2aeb2b3edb9b8bf99eee7a594f747a3897a482ea33fbf1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment-wikijs.json</strong><dd><code>Fix nil slices in deployment-wikijs network policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighbors/deployment-wikijs.json

<li>Replaced <code>ingress</code> null values with empty arrays.<br> <li> Reordered <code>matchLabels</code> to follow <code>ingress</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/412/files#diff-cc9b7d4e85f926ecedeb82d87a2f5da9105cedcea505e7ed6bd7effba7aa3178">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

