### PR TITLE
fix log on assert failure

### DIFF
--- a/tests_scripts/helm/base_network_policy.py
+++ b/tests_scripts/helm/base_network_policy.py
@@ -99,7 +99,7 @@ class BaseNetworkPolicy(BaseHelm):
         """
 
         # we might have multiple actual entries, but we should have at least the same amount of expected entries
-        assert len(expected_entries or '') <= len(actual_entries or ''), f"expected_entries length is not lower or equal to actual_entries length, actual: {len(actual_entries)}, expected: {len(expected_entries)}"
+        assert len(expected_entries or '') <= len(actual_entries or ''), f"expected_entries length is not lower or equal to actual_entries length, actual: {len(actual_entries or '')}, expected: {len(expected_entries or '')}"
 
         # we can't use the identifier for the entry, since IP addresses may change. Instead, we check for all fields that are not IP addresses, and verify that they are equal. If they are all equal, we count this entry as verified.
         for expected_entry in expected_entries or []:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the assertion logging message in `validate_network_neighbor_entry` method to handle cases where `expected_entries` or `actual_entries` might be None.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_network_policy.py</strong><dd><code>Fix assertion logging for network neighbor entry validation</code></dd></summary>
<hr>

tests_scripts/helm/base_network_policy.py

<li>Fixed the logging message in the assertion to handle cases where <br>entries might be None.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/414/files#diff-35ac8c7feff5887b6f1a5260b2f73fa151cda6cc9f28e4024ec718c54a82a0f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

