### PR TITLE
add appliedNetworkPolicyType to attack chain report

### DIFF
--- a/configurations/scenarios_expected_values/attack-chain-5_security-risks-resources_sidebar_R0007.json
+++ b/configurations/scenarios_expected_values/attack-chain-5_security-risks-resources_sidebar_R0007.json
@@ -23,6 +23,7 @@
             "controlID": "C-0260",
             "reportGUID": "fdfa10a9-4b3d-4331-ba44-fad76ea1fac8",
             "frameworkName": "security",
+            "appliedNetworkPolicyType": "unknown",
             "networkPolicyStatus": 1,
             "missingRuntimeInfoReason": 1
         },
@@ -45,6 +46,7 @@
             "controlID": "C-0260",
             "reportGUID": "fdfa10a9-4b3d-4331-ba44-fad76ea1fac8",
             "frameworkName": "security",
+            "appliedNetworkPolicyType": "unknown",
             "networkPolicyStatus": 1,
             "missingRuntimeInfoReason": 1
         }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `appliedNetworkPolicyType` field with value "unknown" to the attack chain report in the JSON configuration file.
- This change enhances the report by including information about the applied network policy type.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>attack-chain-5_security-risks-resources_sidebar_R0007.json</strong><dd><code>Add `appliedNetworkPolicyType` field to attack chain report</code></dd></summary>
<hr>

configurations/scenarios_expected_values/attack-chain-5_security-risks-resources_sidebar_R0007.json

<li>Added <code>appliedNetworkPolicyType</code> field with value "unknown" to two <br>objects.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/417/files#diff-48e6271703feeb3cbf3b64ebfec4ef58dd49f793d8c436c57b60af76ab3434d4">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

