### PR TITLE
chore: Update smart remediation tests for multiple controls

### DIFF
--- a/tests_scripts/helm/smart_remediation.py
+++ b/tests_scripts/helm/smart_remediation.py
@@ -216,6 +216,7 @@ class SmartRemediationNew(BaseKubescape, BaseHelm):
 
         Logger.logger.info(f"3. Start testing controls: {control_to_files.keys()}")
 
+        previous_report_guid = ""
         for control, files in control_to_files.items():
             namespace = control_to_namespace[control]
             workload_fix_file = files[1]
@@ -230,9 +231,11 @@ class SmartRemediationNew(BaseKubescape, BaseHelm):
 
             Logger.logger.info(f"Get report guid for control: {control}")
             report_guid = self.get_report_guid(
-                cluster_name=cluster, wait_to_result=True, framework_name="AllControls"
+                cluster_name=cluster, wait_to_result=True, framework_name="AllControls", old_report_guid=previous_report_guid
             )
             assert report_guid != "", "report guid is empty for control: {control}"
+
+            previous_report_guid = report_guid
 
             Logger.logger.info(f"Check smart remediation is available for control: {control}")
             body = {"pageNum": 1, "pageSize": 1, "cursor": "", "orderBy": "", "innerFilters": [{
@@ -258,9 +261,11 @@ class SmartRemediationNew(BaseKubescape, BaseHelm):
 
             Logger.logger.info(f"Get report guid for control: {control}")
             report_guid = self.get_report_guid(
-                cluster_name=cluster, wait_to_result=True, framework_name="AllControls"
+                cluster_name=cluster, wait_to_result=True, framework_name="AllControls", old_report_guid=previous_report_guid
             )
             assert report_guid != "", f"report guid is empty for control: {control}"
+
+            previous_report_guid = report_guid
 
             Logger.logger.info(f"Check the issue is resolved for control: {control}")
             body = {"pageNum": 1, "pageSize": 1, "cursor": "", "orderBy": "", "innerFilters": [{


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced the smart remediation tests by adding tracking for the previous report GUID.
- Introduced `previous_report_guid` variable to store the last report GUID.
- Passed `previous_report_guid` to the `get_report_guid` method to ensure continuity.
- Updated `previous_report_guid` after each call to `get_report_guid` to maintain the latest report state.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>smart_remediation.py</strong><dd><code>Enhance smart remediation tests with previous report GUID tracking</code></dd></summary>
<hr>

tests_scripts/helm/smart_remediation.py

<li>Added <code>previous_report_guid</code> variable initialization.<br> <li> Passed <code>previous_report_guid</code> to <code>get_report_guid</code> method.<br> <li> Updated <code>previous_report_guid</code> after each <code>get_report_guid</code> call.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/427/files#diff-08ff828fd531553742618df4f26ef884298b7977110215fb06d694fb1eb2c92b">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

