### PR TITLE
chore: Update skip_on_environment value in system_test_mapping.json

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -1418,7 +1418,7 @@
       "gateway"
     ],
     "description": "test security risk vulnerability type, R-0037",
-    "skip_on_environment": "production",
+    "skip_on_environment": "",
     "owner": "eranm@armosec.io"
   },
   "sr_with_exceptions": {


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the `skip_on_environment` value for the test case with description "test security risk vulnerability type, R-0037" from "production" to an empty string.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Update `skip_on_environment` value in system_test_mapping.json</code></dd></summary>
<hr>

system_test_mapping.json

<li>Updated the <code>skip_on_environment</code> value for a specific test case.<br> <li> Changed from "production" to an empty string.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/431/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

