### PR TITLE
Increase the sleep time for deploying the scenario and applying the f…

### DIFF
--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -62,7 +62,7 @@ class ScenarioManager(base_test.BaseTest):
         Logger.logger.info(f"Applying scenario manifests for {self.test_scenario}")
         deploy_cmd = os.path.join(self.scenario_path, 'deploy_scenario') + ' ' + os.path.join(self.scenario_path , self.test_scenario) + ' --namespace ' + self.namespace
         TestUtil.run_command(command_args=deploy_cmd, display_stdout=True, timeout=300)
-        time.sleep(5)
+        time.sleep(30)
 
     
     def apply_fix(self, fix_type):
@@ -71,7 +71,6 @@ class ScenarioManager(base_test.BaseTest):
         """
         fix_command= os.path.join(self.scenario_path, self.test_scenario, 'fix_' + fix_type) + ' --namespace ' + self.namespace
         TestUtil.run_command(command_args=fix_command, display_stdout=True, timeout=300)
-        time.sleep(5)
   
 
     def trigger_scan(self, trigger_by,  additional_params={}) -> None:
@@ -184,11 +183,15 @@ class AttackChainsScenarioManager(ScenarioManager):
                 return all(self.compare_nodes(obj1[key], obj2[key]) for key in obj1.keys())
 
     def check_attack_chains_results(self, result, expected):
-        """Validate the input content with the expected one.
+        """Validate the attack chains results on the backend
         
-        :param result: content retrieved from backend.
-        :return: True if all the controls passed, False otherwise.
+        :param 
+            result: attack chains retrieved from backend.
+            expected: expected attack chains.
+        :exception Exception: if the content is not as expected.
         """
+
+        assert len(result['response']['attackChains']) == len(expected['response']['attackChains']), f"Length mismatch: result: {len(result['response']['attackChains'])} != expected: {len(expected['response']['attackChains'])}"
         # Some example of assertion needed to recognize attack chain scenarios
         for acid, ac in enumerate(result['response']['attackChains']):
             ac_node_result = result['response']['attackChains'][acid]['attackChainNodes']

--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -62,7 +62,7 @@ class ScenarioManager(base_test.BaseTest):
         Logger.logger.info(f"Applying scenario manifests for {self.test_scenario}")
         deploy_cmd = os.path.join(self.scenario_path, 'deploy_scenario') + ' ' + os.path.join(self.scenario_path , self.test_scenario) + ' --namespace ' + self.namespace
         TestUtil.run_command(command_args=deploy_cmd, display_stdout=True, timeout=300)
-        time.sleep(30)
+        time.sleep(60)
 
     
     def apply_fix(self, fix_type):

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -364,7 +364,6 @@ class ScanAttackChainsWithKubescapeHelmChart(BaseHelm, BaseKubescape):
 
         Logger.logger.info("2.2 verify installation")
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME)
-        time.sleep(10)
 
         Logger.logger.info("3. Verify scenario on backend")
         scenarios_manager.verify_scenario(current_datetime)


### PR DESCRIPTION
### **User description**
…ix to 30 seconds to ensure sufficient time for the operations to complete successfully.


___

### **PR Type**
Enhancement


___

### **Description**
- Increased the sleep time from 5 to 30 seconds after deploying the scenario in `systest_utils/scenarios_manager.py` to ensure sufficient time for operations to complete.
- Removed unnecessary sleep times after applying fixes and verifying running pods.
- Improved the docstring for the `check_attack_chains_results` method to provide better clarity on its parameters and exceptions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scenarios_manager.py</strong><dd><code>Increase sleep time and improve docstrings in scenarios_manager.py</code></dd></summary>
<hr>

systest_utils/scenarios_manager.py

<li>Increased sleep time from 5 to 30 seconds after deploying scenario.<br> <li> Improved docstring for <code>check_attack_chains_results</code> method.<br> <li> Removed sleep time after applying fix.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/434/files#diff-45b40c85bafc6685da4f909cffb6852947ec4525688eb921c8f1f1ac5b4da638">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Remove unnecessary sleep time in ks_microservice.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py

- Removed sleep time after verifying running pods.



</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/434/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

