### PR TITLE
adding kdr slack and teams tests

### DIFF
--- a/configurations/system/tests_cases/runtime_tests.py
+++ b/configurations/system/tests_cases/runtime_tests.py
@@ -1,7 +1,10 @@
 import inspect
-from .structures import KubescapeConfiguration
+
+from tests_scripts.runtime.alerts import enrich_slack_alert_notifications, enrich_teams_alert_notifications
+from tests_scripts.users_notifications.alert_notifications import enrich_slack_alert_channel, enrich_teams_alert_channel, get_messages_from_slack_channel, get_messages_from_teams_channel
+from .structures import KubescapeConfiguration, TestConfiguration
 from os.path import join
-from systest_utils.statics import DEFAULT_DEPLOYMENT_PATH, DEFAULT_SERVICE_PATH, DEFAULT_CONFIGMAP_PATH
+from systest_utils.statics import DEFAULT_DEPLOYMENT_PATH, DEFAULT_KDR_PATHS
 
 
 
@@ -25,3 +28,27 @@ class RuntimeTests(object):
             test_obj=RuntimePoliciesConfigurations,
             create_test_tenant=True,
         )
+    
+    @staticmethod
+    def kdr_teams_alerts():
+        from tests_scripts.runtime.alerts import IncidentsAlerts
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=IncidentsAlerts,
+            deployments=join(DEFAULT_DEPLOYMENT_PATH, "redis_sleep_long"),
+            getMessagesFunc=get_messages_from_teams_channel,
+            enrichAlertChannelFunc=enrich_teams_alert_notifications,
+
+        )
+
+    @staticmethod
+    def kdr_slack_alerts():
+        from tests_scripts.runtime.alerts import IncidentsAlerts
+        return TestConfiguration(
+            name=inspect.currentframe().f_code.co_name,
+            test_obj=IncidentsAlerts,
+            deployments=join(DEFAULT_DEPLOYMENT_PATH, "redis_sleep_long"),
+            getMessagesFunc=get_messages_from_slack_channel,
+            enrichAlertChannelFunc=enrich_slack_alert_notifications,
+        )
+    

--- a/configurations/system/tests_cases/runtime_tests.py
+++ b/configurations/system/tests_cases/runtime_tests.py
@@ -4,7 +4,7 @@ from tests_scripts.runtime.alerts import enrich_slack_alert_notifications, enric
 from tests_scripts.users_notifications.alert_notifications import enrich_slack_alert_channel, enrich_teams_alert_channel, get_messages_from_slack_channel, get_messages_from_teams_channel
 from .structures import KubescapeConfiguration, TestConfiguration
 from os.path import join
-from systest_utils.statics import DEFAULT_DEPLOYMENT_PATH, DEFAULT_KDR_PATHS
+from systest_utils.statics import DEFAULT_DEPLOYMENT_PATH
 
 
 

--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -1502,6 +1502,32 @@
     "skip_on_environment": "",
     "owner": ""
   },
+  "kdr_slack_alerts": {
+    "target": [
+      "Backend"
+    ],
+    "target_repositories": [
+      "cadashboardbe",
+      "event-ingester-service",
+      "config-service"
+    ],
+    "description": "Test kdr incidents is being sent to slack",
+    "skip_on_environment": "",
+    "owner": "eranm@armosec.io"
+  },
+  "kdr_teams_alerts": {
+    "target": [
+      "Backend"
+    ],
+    "target_repositories": [
+      "cadashboardbe",
+      "event-ingester-service",
+      "config-service"
+    ],
+    "description": "Test kdr incidents is being sent to teams",
+    "skip_on_environment": "",
+    "owner": "eranm@armosec.io"
+  },
   "sr_ac_scan_status": {
     "target": [
       "In cluster",

--- a/systest_utils/statics.py
+++ b/systest_utils/statics.py
@@ -72,7 +72,6 @@ DEFAULT_NOTIFICATIONS_DEPLOYMENT_PATH = os.path.join(DEFAULT_NOTIFICATIONS_PATHS
 DEFAULT_NOTIFICATIONS_JOB_PATH = os.path.join(DEFAULT_NOTIFICATIONS_PATHS, 'jobs')
 
 # kdr
-DEFAULT_KDR_PATHS = os.path.abspath(os.path.join('configurations', 'kdr'))
 DEFAULT_KDR_DEPLOYMENT_PATH = os.path.join(DEFAULT_K8S_PATHS, 'deployments')
 
 DEFAULT_DEPLOY_INTEGRATIONS_PATH = os.path.join(DEFAULT_K8S_PATHS, 'integrations')

--- a/systest_utils/statics.py
+++ b/systest_utils/statics.py
@@ -69,6 +69,11 @@ DEFAULT_INPUT_YAML_PATH = os.path.join(RESOURCES_PATH, 'kubescape', 'yaml_file')
 # notifications
 DEFAULT_NOTIFICATIONS_PATHS = os.path.abspath(os.path.join('configurations', 'notifications'))
 DEFAULT_NOTIFICATIONS_DEPLOYMENT_PATH = os.path.join(DEFAULT_NOTIFICATIONS_PATHS, 'deployments')
+DEFAULT_NOTIFICATIONS_JOB_PATH = os.path.join(DEFAULT_NOTIFICATIONS_PATHS, 'jobs')
+
+# kdr
+DEFAULT_KDR_PATHS = os.path.abspath(os.path.join('configurations', 'kdr'))
+DEFAULT_KDR_DEPLOYMENT_PATH = os.path.join(DEFAULT_K8S_PATHS, 'deployments')
 
 DEFAULT_DEPLOY_INTEGRATIONS_PATH = os.path.join(DEFAULT_K8S_PATHS, 'integrations')
 DEFAULT_INTEGRATIONS_PATH = os.path.abspath(os.path.join('configurations', 'integrations'))

--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -144,6 +144,10 @@ class IncidentsAlerts(AlertNotifications, RuntimePoliciesConfigurations):
 
 def assert_runtime_incident_message_sent(messages, cluster):
         found = 0
+        Logger.logger.info(f"total messages found: {len(messages)}, looking for runtime incident messages")
+        if len(messages) > 0:
+            Logger.logger.info(f"first message: {messages[0]}")
+            
         for message in messages:
             message_string = str(message)
             if "New threat found" in message_string and cluster in message_string and "redis" in message_string:

--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -159,9 +159,7 @@ def enrich_teams_alert_notifications(data):
     data["notifications"]  =[
         {
             "provider": "teams",
-            "webhook" :{
-                "id": get_env("CHANNEL_WEBHOOK")
-            }
+            "teamsWebhookURL" : get_env("CHANNEL_WEBHOOK")
         }
     ]
 

--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -49,6 +49,16 @@ class IncidentsAlerts(AlertNotifications, RuntimePoliciesConfigurations):
         self.test_policy_guids = []
 
     def start(self):
+        """
+        agenda:
+        1. get runtime incidents rulesets
+        2. enrich the new runtime policy with alert notifications
+        3. create new runtime policy
+        4. Install kubescape
+        5. apply the deployment that will generate the incident
+        6. wait for the runtime incidents to be generated
+        7. verify messages were sent
+        """
         assert self.backend is not None, f'the test {self.test_driver.test_name} must run with backend'
  
 

--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -1,0 +1,164 @@
+
+
+import json
+from random import random
+import time
+from configurations.system.tests_cases.structures import TestConfiguration
+from infrastructure.kubectl_wrapper import KubectlWrapper
+from systest_utils.systests_utilities import TestUtil
+from systest_utils.tests_logger import Logger
+from tests_scripts.base_test import BaseTest
+from tests_scripts.runtime.policies import POLICY_CREATED_RESPONSE, RuntimePoliciesConfigurations
+from tests_scripts.users_notifications.alert_notifications import TEST_NAMESPACE, AlertNotifications, get_env
+
+
+class IncidentsAlerts(AlertNotifications, RuntimePoliciesConfigurations):
+    def __init__(self, test_obj: TestConfiguration = None, backend=None, test_driver=None):
+        super(IncidentsAlerts, self).__init__(test_obj=test_obj, backend=backend, test_driver=test_driver)
+
+        self.helm_kwargs = {
+            "capabilities.configurationScan": "disable",
+            "capabilities.continuousScan": "disable",
+            "capabilities.nodeScan": "disable",
+            "capabilities.vulnerabilityScan": "disable",
+            "grypeOfflineDB.enabled": "false",
+            # not clear why
+            "capabilities.relevancy": "enable",
+            # enable application profile, malware and runtime detection
+            "capabilities.runtimeObservability": "enable",
+            "capabilities.malwareDetection": "enable",
+            "capabilities.runtimeDetection": "enable",
+            "capabilities.nodeProfileService": "enable",
+            "alertCRD.installDefault": True,
+            "alertCRD.scopeClustered": True,
+            # short learning period
+            "nodeAgent.config.maxLearningPeriod": "60s",
+            "nodeAgent.config.learningPeriod": "50s",
+            "nodeAgent.config.updatePeriod": "30s",
+            "nodeAgent.config.nodeProfileInterval": "1m",
+            # "nodeAgent.image.repository": "docker.io/amitschendel/node-agent",
+            # "nodeAgent.image.tag": "v0.0.5",
+        }
+        test_helm_kwargs = self.test_obj.get_arg("helm_kwargs")
+        if test_helm_kwargs:
+            self.helm_kwargs.update(test_helm_kwargs)
+
+        self.fw_name = None
+        self.cluster = None
+        self.wait_for_agg_to_end = False
+        self.test_policy_guids = []
+
+    def start(self):
+        assert self.backend is not None, f'the test {self.test_driver.test_name} must run with backend'
+ 
+
+        self.cluster, namespace = self.setup(apply_services=False)
+
+        before_test_message_ts = time.time()
+        
+
+        Logger.logger.info("1. get runtime incidents rulesets")
+        res = self.backend.get_runtime_incidents_rulesets()
+        incident_rulesets = json.loads(res.text)
+
+        incident_rulesets_guids = [rule["guid"] for rule in incident_rulesets["response"] if rule["name"] == "Anomaly"]
+
+
+        # Update the name field
+        new_runtime_policy_body = {
+            "name": f"Malware-new-systest-" + self.cluster,    
+            "description": "Default Malware RuleSet System Test",
+            "enabled": True,
+            "scope": {},
+            "ruleSetType": "Managed",
+            "managedRuleSetIDs": incident_rulesets_guids,
+            "notifications": [],
+            "actions": []
+        }
+
+
+        Logger.logger.info("2. enrich the new runtime policy with alert notifications")
+        self.test_obj["enrichAlertChannelFunc"](new_runtime_policy_body)
+
+
+        Logger.logger.info("3. create new runtime policy")
+        new_policy_guid = self.validate_new_policy(new_runtime_policy_body)
+        self.test_policy_guids.append(new_policy_guid)
+
+
+        Logger.logger.info('4. Install kubescape')
+        self.install_kubescape(helm_kwargs=self.helm_kwargs)
+
+        Logger.logger.info('5. apply the deployment that will generate the incident')
+        workload_objs: list = self.apply_directory(path=self.test_obj["deployments"], namespace=namespace)
+        self.verify_all_pods_are_running(namespace=namespace, workload=workload_objs, timeout=240)
+
+        wlids = self.get_wlid(workload=workload_objs, namespace=namespace, cluster=self.cluster)
+        if isinstance(wlids, str):
+            wlids = [wlids]
+
+        Logger.logger.info('6. wait for the runtime incidents to be generated')
+        self.wait_for_report(self.verify_running_pods, sleep_interval=5, timeout=180, namespace=namespace)
+
+        Logger.logger.info(
+            f'workloads are running, waiting for application profile finalizing before exec into pod {wlids}')
+        self.wait_for_report(self.verify_application_profiles, wlids=wlids, namespace=namespace)
+        time.sleep(6)
+        self.exec_pod(wlid=wlids[0], command="ls -l /tmp")
+        
+
+        Logger.logger.info('7. verify messages were sent')
+        res = self.wait_for_report(self.assert_all_messages_sent, begin_time=before_test_message_ts, cluster=self.cluster)
+        return self.cleanup()
+    
+    def cleanup(self):
+        for policy_guid in self.test_policy_guids:
+            body = {
+                "innerFilters": [
+                    {
+                        "guid": policy_guid,
+                    }
+                ]
+            }
+            self.backend.delete_runtime_policies(body)
+        return super().cleanup()
+
+
+    def assert_all_messages_sent(self, begin_time, cluster):
+        messages = self.test_obj["getMessagesFunc"](begin_time)
+        found = str(messages).count(cluster)
+        assert found > 0, f"expected to have at least 1 message, found {found}"
+        assert_runtime_incident_message_sent(messages, cluster)
+           
+
+
+def assert_runtime_incident_message_sent(messages, cluster):
+        found = 0
+        for message in messages:
+            message_string = str(message)
+            if "New threat found" in message_string and cluster in message_string and "redis" in message_string:
+                found += 1
+        assert found > 0, "expected to have at least one runtime incident message"
+
+
+def enrich_teams_alert_notifications(data):
+    data["notifications"]  =[
+        {
+            "provider": "teams",
+            "webhook" :{
+                "id": get_env("CHANNEL_WEBHOOK")
+            }
+        }
+    ]
+
+
+def enrich_slack_alert_notifications(data):
+    data["notifications"] = [
+        {
+            "provider": "slack",
+            "slackChannel": {
+                "channelID": get_env("SLACK_CHANNEL_ID"),
+                "channelName": "dev-system-tests"
+            }
+        }
+    ]

--- a/tests_scripts/runtime/policies.py
+++ b/tests_scripts/runtime/policies.py
@@ -170,8 +170,8 @@ class RuntimePoliciesConfigurations(BaseTest):
 
         res = self.backend.get_runtime_policies_list(new_generated_runtime_policy_body)
         incident_policies = json.loads(res.text)["response"]
-        props_to_check = ["name", "scope", "ruleSetType", "managedRuleSetIDs", "notifications", "actions"]
-        assert len(incident_policies)  == 1, f"failed to get new runtime policy, expected 1 but got {len(incident_policies)}, got result {incident_policies}"
+        props_to_check = ["name", "scope", "ruleSetType", "managedRuleSetIDs", "actions"]
+        assert len(incident_policies)  > 0, f"failed to get new runtime policy, expected more than 1 but got {len(incident_policies)}, got result {incident_policies}"
 
         for prop in props_to_check:
             assert incident_policies[0][prop] == body[prop], f"failed to get new runtime policy, expected '{prop}' {body[prop]} but got {incident_policies[0][prop]}, got result {incident_policies}"


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Added new test configurations for Slack and Teams alerts in `runtime_tests.py`.
- Updated default paths for notifications and KDR configurations in `statics.py`.
- Introduced `ResourceFieldEncoder` and `verify_application_profiles` in `base_helm.py`.
- Created `IncidentsAlerts` class for handling incident alerts and enriching notifications in `alerts.py`.
- Removed redundant `ResourceFieldEncoder` and `verify_application_profiles` in `incidents.py`.
- Updated policy validation to exclude notifications in `policies.py`.
- Enhanced alert channel creation and Kubescape installation in `alert_notifications.py`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime_tests.py</strong><dd><code>Add Slack and Teams alert test configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/runtime_tests.py

<li>Added new test configurations for Slack and Teams alerts.<br> <li> Updated import statements to include new alert notification functions.<br> <li> Introduced <code>kdr_teams_alerts</code> and <code>kdr_slack_alerts</code> methods.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/436/files#diff-9c1946b453a24f271acd0baadfeddc2605cc63db31b2c3f82e4d1f703d68f72c">+30/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statics.py</strong><dd><code>Update default paths for notifications and KDR configurations</code></dd></summary>
<hr>

systest_utils/statics.py

<li>Added default paths for KDR configurations.<br> <li> Updated notifications paths.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/436/files#diff-741805bf43ee8065d3c6f32870106551b7a27a6cbc692f403e5da6cbeefeb819">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base_helm.py</strong><dd><code>Add ResourceFieldEncoder and application profiles verification</code></dd></summary>
<hr>

tests_scripts/helm/base_helm.py

<li>Added <code>ResourceFieldEncoder</code> class for JSON encoding.<br> <li> Introduced <code>verify_application_profiles</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/436/files#diff-821c02ceccfbba391f88d154d40cb796c6c8700a933156e354cd781f646e6c6a">+30/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>alerts.py</strong><dd><code>Implement incident alerts handling and notification enrichment</code></dd></summary>
<hr>

tests_scripts/runtime/alerts.py

<li>Created new <code>IncidentsAlerts</code> class for handling incident alerts.<br> <li> Added methods for enriching alert notifications for Slack and Teams.<br> <li> Implemented alert notification and runtime policy creation logic.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/436/files#diff-7a2859d9e17d4bbd81f97e0eb52528a9740488a51fec22d5e3f852e593c5f3ad">+164/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>incidents.py</strong><dd><code>Remove redundant ResourceFieldEncoder and application profiles </code><br><code>verification</code></dd></summary>
<hr>

tests_scripts/runtime/incidents.py

<li>Removed <code>ResourceFieldEncoder</code> class.<br> <li> Removed <code>verify_application_profiles</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/436/files#diff-6f3165404f3f21321f01ad4b86d65b7ae44d169e8b0ace497200a7dbe7b4ca90">+0/-24</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>policies.py</strong><dd><code>Update policy validation to exclude notifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/runtime/policies.py

<li>Updated <code>validate_new_policy</code> method to remove notifications from <br>properties check.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/436/files#diff-530ebb07017f4ebc1205dad9f611b6ace87e75ddb61be772ba3da39948a42e34">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>alert_notifications.py</strong><dd><code>Enhance alert channel creation and Kubescape installation</code></dd></summary>
<hr>

tests_scripts/users_notifications/alert_notifications.py

<li>Added optional parameters to <code>create_alert_channel</code> and <br><code>get_alert_channel_payload</code> methods.<br> <li> Modified <code>install_kubescape</code> method to accept <code>helm_kwargs</code>.<br> <li> Added condition to check <code>fw_name</code> before deleting custom framework.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/436/files#diff-060c88bdcfa726da38c03b70cd0a8200d036919e36d7aae93d871504ac2d8ec5">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

