### PR TITLE
chore: Add incidents verification in runtime alerts test

### DIFF
--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -131,7 +131,9 @@ class IncidentsAlerts(AlertNotifications, RuntimePoliciesConfigurations):
         
 
         Logger.logger.info('7. verify messages were sent')
-        res = self.wait_for_report(self.assert_all_messages_sent, begin_time=before_test_message_ts, cluster=self.cluster)
+        res = self.wait_for_report(self.assert_all_messages_sent, 
+                                   timeout=5 * 60, 
+                                   begin_time=before_test_message_ts, cluster=self.cluster)
         return self.cleanup()
     
     def verify_incident_completed(self, incident_id):


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the runtime alerts test by adding verification for incidents.
- Implemented `verify_incident_completed` method to ensure incidents are marked as completed.
- Implemented `verify_incident_in_backend_list` method to retrieve incidents based on filters.
- Added assertions to check that there are no related alerts in the incident.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alerts.py</strong><dd><code>Add incidents verification and related assertions in runtime alerts </code><br><code>test</code></dd></summary>
<hr>

tests_scripts/runtime/alerts.py

<li>Added verification for incidents in runtime alerts test.<br> <li> Implemented <code>verify_incident_completed</code> method to check incident status.<br> <li> Implemented <code>verify_incident_in_backend_list</code> method to fetch incidents <br>list.<br> <li> Added assertions to ensure no related alerts in the incident.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/437/files#diff-7a2859d9e17d4bbd81f97e0eb52528a9740488a51fec22d5e3f852e593c5f3ad">+32/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

