### PR TITLE
chore: Remove logging statement in IncidentsAlerts class

### DIFF
--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -204,8 +204,7 @@ def enrich_slack_alert_notifications(data):
         {
             "provider": "slack",
             "slackChannel": {
-                "channelID": get_env("SLACK_CHANNEL_ID"),
-                "channelName": "dev-system-tests"
+                "id": get_env("SLACK_CHANNEL_ID")
             }
         }
     ]

--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -122,7 +122,6 @@ class IncidentsAlerts(AlertNotifications, RuntimePoliciesConfigurations):
                                        cluster=self.cluster, namespace=namespace,
                                        incident_name="Unexpected process launched")
         
-        Logger.logger.info(f"Got incidents list {json.dumps(incs)}")
         inc, _ = self.wait_for_report(self.verify_incident_completed, timeout=5 * 60, sleep_interval=5,
                                       incident_id=incs[0]['guid'])
         Logger.logger.info(f"Got incident {json.dumps(inc)}")

--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -94,6 +94,8 @@ class IncidentsAlerts(AlertNotifications, RuntimePoliciesConfigurations):
 
         Logger.logger.info("3. create new runtime policy")
         new_policy_guid = self.validate_new_policy(new_runtime_policy_body)
+        
+        Logger.logger.info(f"New policy created with guid {new_policy_guid}")
         self.test_policy_guids.append(new_policy_guid)
 
 

--- a/tests_scripts/runtime/policies.py
+++ b/tests_scripts/runtime/policies.py
@@ -173,6 +173,8 @@ class RuntimePoliciesConfigurations(BaseTest):
         props_to_check = ["name", "scope", "ruleSetType", "managedRuleSetIDs", "actions"]
         assert len(incident_policies)  > 0, f"failed to get new runtime policy, expected more than 1 but got {len(incident_policies)}, got result {incident_policies}"
 
+        Logger.logger.info(f"New policy created: {json.dumps(incident_policies[0], indent=4)}")
+
         for prop in props_to_check:
             assert incident_policies[0][prop] == body[prop], f"failed to get new runtime policy, expected '{prop}' {body[prop]} but got {incident_policies[0][prop]}, got result {incident_policies}"
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed a logging statement in the `IncidentsAlerts` class to clean up the output.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alerts.py</strong><dd><code>Remove logging statement in `IncidentsAlerts` class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/runtime/alerts.py

- Removed a logging statement that outputs the incidents list.



</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/438/files#diff-7a2859d9e17d4bbd81f97e0eb52528a9740488a51fec22d5e3f852e593c5f3ad">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

