### PR TITLE
chore: Add users-notification-service to system test mapping

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -1509,7 +1509,8 @@
     "target_repositories": [
       "cadashboardbe",
       "event-ingester-service",
-      "config-service"
+      "config-service",
+      "users-notification-service"
     ],
     "description": "Test kdr incidents is being sent to slack",
     "skip_on_environment": "",
@@ -1522,7 +1523,8 @@
     "target_repositories": [
       "cadashboardbe",
       "event-ingester-service",
-      "config-service"
+      "config-service",
+      "users-notification-service"
     ],
     "description": "Test kdr incidents is being sent to teams",
     "skip_on_environment": "",


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `users-notification-service` to the `target_repositories` list in `system_test_mapping.json` for two test cases.
- Ensures that the `users-notification-service` is included in system tests for incidents sent to Slack and Teams.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Add `users-notification-service` to system test mapping</code>&nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json

<li>Added <code>users-notification-service</code> to the <code>target_repositories</code> list for <br>two test cases.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/439/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

