### PR TITLE
Revert "chore: Update incident name in IncidentsAlerts class"

### DIFF
--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -122,7 +122,7 @@ class IncidentsAlerts(AlertNotifications, RuntimePoliciesConfigurations):
         Logger.logger.info("Get incidents list")
         incs, _ = self.wait_for_report(self.verify_incident_in_backend_list, timeout=30, sleep_interval=5,
                                        cluster=self.cluster, namespace=namespace,
-                                       incident_name="Exec to pod")
+                                       incident_name="Unexpected process launched")
         
         inc, _ = self.wait_for_report(self.verify_incident_completed, timeout=5 * 60, sleep_interval=5,
                                       incident_id=incs[0]['guid'])


### PR DESCRIPTION
### **User description**
Reverts armosec/system-tests#442


___

### **PR Type**
Bug fix


___

### **Description**
- Reverted the incident name in the `start` method of the `alerts.py` script from "Exec to pod" back to "Unexpected process launched".



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alerts.py</strong><dd><code>Revert incident name change in `start` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/runtime/alerts.py

<li>Reverted incident name from "Exec to pod" back to "Unexpected process <br>launched"<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/443/files#diff-7a2859d9e17d4bbd81f97e0eb52528a9740488a51fec22d5e3f852e593c5f3ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

