### PR TITLE
chore: Update networkPolicyStatus in attack-chain-5_security-risks-re…

### DIFF
--- a/configurations/scenarios_expected_values/attack-chain-5_security-risks-resources_sidebar_R0007.json
+++ b/configurations/scenarios_expected_values/attack-chain-5_security-risks-resources_sidebar_R0007.json
@@ -24,7 +24,7 @@
             "reportGUID": "fdfa10a9-4b3d-4331-ba44-fad76ea1fac8",
             "frameworkName": "security",
             "appliedNetworkPolicyType": "unknown",
-            "networkPolicyStatus": 1,
+            "networkPolicyStatus": 2,
             "missingRuntimeInfoReason": 1
         },
         {
@@ -47,7 +47,7 @@
             "reportGUID": "fdfa10a9-4b3d-4331-ba44-fad76ea1fac8",
             "frameworkName": "security",
             "appliedNetworkPolicyType": "unknown",
-            "networkPolicyStatus": 1,
+            "networkPolicyStatus": 2,
             "missingRuntimeInfoReason": 1
         }
     ],


### PR DESCRIPTION
### **User description**
…sources_sidebar_R0007.json


___

### **PR Type**
enhancement


___

### **Description**
- Updated the `networkPolicyStatus` field from 1 to 2 in the JSON configuration file `attack-chain-5_security-risks-resources_sidebar_R0007.json`.
- This change affects two entries within the file, aligning the network policy status with the desired configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>attack-chain-5_security-risks-resources_sidebar_R0007.json</strong><dd><code>Update network policy status values in JSON configuration</code></dd></summary>
<hr>

configurations/scenarios_expected_values/attack-chain-5_security-risks-resources_sidebar_R0007.json

<li>Updated <code>networkPolicyStatus</code> from 1 to 2 in two instances.<br> <li> No other changes were made to the file.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/445/files#diff-48e6271703feeb3cbf3b64ebfec4ef58dd49f793d8c436c57b60af76ab3434d4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

