### PR TITLE
chore: Disable waiting for aggregation to end in BaseTest

### DIFF
--- a/tests_scripts/base_test.py
+++ b/tests_scripts/base_test.py
@@ -36,7 +36,7 @@ class BaseTest(object):
         
         self.test_started_at = datetime.now(timezone.utc).astimezone().isoformat()
         self.cluster_deleted = False
-        self.wait_for_agg_to_end = True
+        self.wait_for_agg_to_end = False
 
         # objects
         self.test_driver = test_driver


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Changed the default behavior in `BaseTest` by setting `wait_for_agg_to_end` to `False`, which disables waiting for aggregation to end.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_test.py</strong><dd><code>Disable waiting for aggregation to end in BaseTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/base_test.py

<li>Changed the default value of <code>wait_for_agg_to_end</code> from <code>True</code> to <code>False</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/448/files#diff-87d918802c9bc70e9af861f91b5d631f022c697efb2f1091ffec0c7dca5a94ac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

