### PR TITLE
pin version of deepdiff to avoid regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,5 @@ struct-diff==0.9.0.post7
 junit_xml
 wheel
 psutil
-deepdiff
+deepdiff==7.0.1
 slack_sdk


### PR DESCRIPTION
### **PR Type**
dependencies


___

### **Description**
- Pinned the `deepdiff` library version to `7.0.1` in `requirements.txt` to avoid potential regressions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Pin `deepdiff` version to `7.0.1` in requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

<li>Pinned the version of <code>deepdiff</code> to <code>7.0.1</code>.<br> <li> Prevent potential regressions by specifying the version.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/453/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

