### PR TITLE
set podScanGuardTime to 1m to fix tests

### DIFF
--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -131,6 +131,8 @@ class BaseHelm(BaseK8S):
         if "nodeAgent.config.updatePeriod" not in helm_kwargs:
             helm_kwargs.update({"nodeAgent.config.updatePeriod": self.filtered_sbom_update_time})
 
+        helm_kwargs.update({"operator.podScanGuardTime": "1m"})
+
         create_namespace = True
         if self.docker_default_secret:
             self.create_namespace(unique_name=False, name=namespace)


### PR DESCRIPTION
### **PR Type**
tests, bug_fix


___

### **Description**
- Added the `operator.podScanGuardTime` parameter with a value of "1m" to the Helm chart installation process to fix test issues.
- This change ensures that the pod scan guard time is consistently set, potentially addressing timing-related test failures.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_helm.py</strong><dd><code>Set podScanGuardTime to 1m in Helm chart installation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/base_helm.py

<li>Added <code>operator.podScanGuardTime</code> parameter with a value of "1m" to <br><code>helm_kwargs</code>.<br> <li> Ensures the pod scan guard time is set during the Helm chart <br>installation.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/455/files#diff-821c02ceccfbba391f88d154d40cb796c6c8700a933156e354cd781f646e6c6a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

