### PR TITLE
lower podScanGuardTime override to avoid timeouts

### DIFF
--- a/tests_scripts/helm/base_helm.py
+++ b/tests_scripts/helm/base_helm.py
@@ -131,7 +131,7 @@ class BaseHelm(BaseK8S):
         if "nodeAgent.config.updatePeriod" not in helm_kwargs:
             helm_kwargs.update({"nodeAgent.config.updatePeriod": self.filtered_sbom_update_time})
 
-        helm_kwargs.update({"operator.podScanGuardTime": "1m"})
+        helm_kwargs.update({"operator.podScanGuardTime": "5s"})
 
         create_namespace = True
         if self.docker_default_secret:


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Adjusted the `podScanGuardTime` override in the Helm chart installation script from "1m" to "5s" to prevent timeouts.
- This change aims to enhance the reliability of the Helm chart installation process by reducing the guard time.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_helm.py</strong><dd><code>Adjust `podScanGuardTime` to prevent timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/base_helm.py

<li>Changed the <code>podScanGuardTime</code> override value from "1m" to "5s".<br> <li> This adjustment is intended to avoid timeouts.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/456/files#diff-821c02ceccfbba391f88d154d40cb796c6c8700a933156e354cd781f646e6c6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

