### PR TITLE
fix check

### DIFF
--- a/tests_scripts/helm/jira_integration.py
+++ b/tests_scripts/helm/jira_integration.py
@@ -221,12 +221,16 @@ class JiraIntegration(BaseKubescape, BaseHelm):
         security_risk_ids = [security_risk_id] if security_risk_id else []
         r = self.backend.get_security_risks_list(self.cluster, self.namespace, security_risk_ids, other_filters=other_filters)
         response = json.loads(r.text)
+        if response["response"] is None:
+            response["response"] = []
         assert len(response["response"]) == 1 , "Expected one security risk"
         return response["response"][0]
 
     def verify_security_risks_resource_exists(self, security_risk_id):
         r = self.backend.get_security_risks_resources(cluster_name=self.cluster, namespace=self.namespace, security_risk_id=security_risk_id, other_filters={"tickets":"|exists"})
         response = json.loads(r.text)
+        if response["response"] is None:
+            response["response"] = []
         assert len(response["response"]) == 1 , "Expected one resource for security risks"
 
     def verify_security_risks_resource_missing(self, security_risk_id):
@@ -238,6 +242,8 @@ class JiraIntegration(BaseKubescape, BaseHelm):
     def get_security_risks_resource(self, security_risk_id, other_filters={}):
         r = self.backend.get_security_risks_resources(cluster_name=self.cluster, namespace=self.namespace, security_risk_id=security_risk_id, other_filters=other_filters)
         response = json.loads(r.text)
+        if response["response"] is None:
+            response["response"] = []
         assert len(response["response"]) == 1 , "Expected one resource for security risks"
         return response["response"][0]
     


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a bug where `None` responses could cause assertion errors by initializing such responses to empty lists.
- Improved reliability of security risks checks by ensuring assertions are made on valid lists.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_integration.py</strong><dd><code>Add handling for None responses in security risks checks</code>&nbsp; </dd></summary>
<hr>

tests_scripts/helm/jira_integration.py

<li>Added checks to handle <code>None</code> responses by initializing them to empty <br>lists.<br> <li> Ensured assertions are made on non-<code>None</code> lists to prevent errors.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/464/files#diff-5a901f2fef79a9c4f309e5fe5da5f599737904ffbe50627fc852419377b5b64a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

