### PR TITLE
disable test in prod

### DIFF
--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -118,6 +118,11 @@ class ScanSecurityRisksWithKubescapeHelmChart(BaseHelm, BaseKubescape):
         assert self.backend != None;
         f'the test {self.test_driver.test_name} must run with backend'
 
+        # skip test for production backend
+        if self.test_driver.test_name == "sr_r_0037_vulnerability" and self.backend.server == "https://api.armosec.io":
+            Logger.logger.info(f"Skipping test '{self.test_driver.test_name}' for production backend")
+            return statics.SUCCESS, ""
+            
         self.ignore_agent = True
         cluster, namespace = self.setup(apply_services=False)
 


### PR DESCRIPTION
### **PR Type**
tests


___

### **Description**
- Added logic to skip the `sr_r_0037_vulnerability` test when running against the production backend (`https://api.armosec.io`).
- Implemented logging to inform when the test is being skipped.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Skip specific test for production backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py

<li>Added a condition to skip a specific test for the production backend.<br> <li> Logged a message when the test is skipped.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/465/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

