### PR TITLE
Temp disable

### DIFF
--- a/tests_scripts/helm/jira_integration.py
+++ b/tests_scripts/helm/jira_integration.py
@@ -15,10 +15,6 @@ class JiraIntegration(BaseKubescape, BaseHelm):
             kubernetes_obj=kubernetes_obj,
         )
 
-        if self.test_driver.test_name == "jira_integration" and self.backend.server == "https://api.armosec.io": # skip test for production
-            Logger.logger.info(f"Skipping test '{self.test_driver.test_name}' for production backend")
-            return statics.SUCCESS, ""
-
         self.helm_kwargs = {
             "capabilities.relevancy": "enable",
             "capabilities.configurationScan": "enable",
@@ -42,6 +38,9 @@ class JiraIntegration(BaseKubescape, BaseHelm):
     
 
     def start(self):
+        if self.test_driver.test_name == "jira_integration" and self.backend.server == "https://api.armosec.io": # skip test for production
+            Logger.logger.info(f"Skipping test '{self.test_driver.test_name}' for production backend")
+            return statics.SUCCESS, ""
         Logger.logger.info(f"Setup jira configuration")
         self.setup_jira_config()
         Logger.logger.info(f"Setup cluster and run posture scan")

--- a/tests_scripts/helm/jira_integration.py
+++ b/tests_scripts/helm/jira_integration.py
@@ -15,6 +15,10 @@ class JiraIntegration(BaseKubescape, BaseHelm):
             kubernetes_obj=kubernetes_obj,
         )
 
+        if self.test_driver.test_name == "jira_integration" and self.backend.server == "https://api.armosec.io": # skip test for production
+            Logger.logger.info(f"Skipping test '{self.test_driver.test_name}' for production backend")
+            return statics.SUCCESS, ""
+
         self.helm_kwargs = {
             "capabilities.relevancy": "enable",
             "capabilities.configurationScan": "enable",

--- a/tests_scripts/helm/synchronizer.py
+++ b/tests_scripts/helm/synchronizer.py
@@ -444,6 +444,10 @@ class SynchronizerProxy(BaseSynchronizer):
             self.backend != None
         ), f"the test {self.test_driver.test_name} must run with backend"
 
+        if self.test_driver.test_name == "synchronizer_proxy" and self.backend.server == "https://api.armosec.io": # skip test for production
+            Logger.logger.info(f"Skipping test '{self.test_driver.test_name}' for production backend")
+            return statics.SUCCESS, ""
+        
         cluster, namespace_1 = self.setup(apply_services=False)
 
         Logger.logger.info(f"1. Apply workloads")


### PR DESCRIPTION
### **PR Type**
tests


___

### **Description**
- Refactored the logic to skip tests in production environment by moving the condition from the constructor to the `start` method in `jira_integration.py`.
- This change ensures that the test skipping logic is only executed when the `start` method is called, rather than during object initialization.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_integration.py</strong><dd><code>Refactor test skipping logic for production environment</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/jira_integration.py

<li>Moved the condition to skip tests in production from the constructor <br>to the <code>start</code> method.<br> <li> Removed the early return in the constructor for production <br>environment.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/467/files#diff-5a901f2fef79a9c4f309e5fe5da5f599737904ffbe50627fc852419377b5b64a">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

