### PR TITLE
add registryType to delete registry request

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -1856,6 +1856,7 @@ class ControlPanelAPI(object):
                 "clusterName": cj["clusterName"],
                 "registryProvider": cj["registryProvider"],
                 "registryName": cj["registryName"],
+                "registryType": cj['registryType'],
                 "action": statics.DELETE_REGISTRY_CJ_COMMAND
             }
         ]


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `delete_registry_scan_cronjob` function by adding the `registryType` parameter to the request body.
- This change ensures that the registry type is considered when deleting a registry scan cronjob.



___



PRDescriptionHeader.CHANGES_WALKTHROUGH
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Add `registryType` to delete registry scan cronjob request</code></dd></summary>
<hr>

infrastructure/backend_api.py

<li>Added <code>registryType</code> to the body of the delete registry scan cronjob <br>request.<br> <li> Ensures that the <code>delete_registry_scan_cronjob</code> function includes the <br>registry type in its operations.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/474/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information