### PR TITLE
scan all controls fw instead of security fw

### DIFF
--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -83,13 +83,13 @@ class ScenarioManager(base_test.BaseTest):
             self.backend.create_kubescape_job_request(
                 cluster_name=self.cluster,
                 trigger_by=trigger_by,
-                framework_list=["security"],
+                framework_list=["allcontrols"],
                 with_host_sensor="false"
             )
         else:
             self.backend.trigger_posture_scan(
                 cluster_name=self.cluster,
-                framework_list=["security"],
+                framework_list=["allcontrols"],
                 with_host_sensor="false",
                 additional_params=additional_params
                 )

--- a/systest_utils/scenarios_manager.py
+++ b/systest_utils/scenarios_manager.py
@@ -89,6 +89,8 @@ class ScenarioManager(base_test.BaseTest):
         else:
             self.backend.trigger_posture_scan(
                 cluster_name=self.cluster,
+                 # scanning "allcontrols" framework will trigger a scan for the "security" framework, whereas scanning "security" framework alone is not enough 
+                 # since the BE looks at the last scan and scans containing only "security" framework are not returned as last posture scan
                 framework_list=["allcontrols"],
                 with_host_sensor="false",
                 additional_params=additional_params


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `trigger_scan` method in `scenarios_manager.py` to change the framework list from `["security"]` to `["allcontrols"]`.
- This change affects both the `create_kubescape_job_request` and `trigger_posture_scan` methods, ensuring that scans are triggered for all controls rather than just security.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scenarios_manager.py</strong><dd><code>Update scan framework from security to all controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

systest_utils/scenarios_manager.py

<li>Changed the framework list from <code>["security"]</code> to <code>["allcontrols"]</code> in <br><code>trigger_scan</code> method.<br> <li> Updated both <code>create_kubescape_job_request</code> and <code>trigger_posture_scan</code> <br>calls.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/483/files#diff-45b40c85bafc6685da4f909cffb6852947ec4525688eb921c8f1f1ac5b4da638">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information