### PR TITLE
disable submit for networkpolicy tests

### DIFF
--- a/configurations/system/tests_cases/network_policy_tests.py
+++ b/configurations/system/tests_cases/network_policy_tests.py
@@ -29,6 +29,7 @@ class NetworkPolicyTests(object):
                 "configurations/network-policy/expected-generated-network-policy/deployment-nginx.json",
                 ],
             helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
+                         "storage.forceVirtualCrds": "true",
                          statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s',
                          statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'
                          }
@@ -65,7 +66,10 @@ class NetworkPolicyTests(object):
                 "configurations/network-policy/expected-generated-network-policy/deployment-nginx.json",
                 ],
             helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
-                         statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+                         "storage.forceVirtualCrds": "true",
+                         statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s',
+                         statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'
+                         }
         )
 
     @staticmethod
@@ -89,7 +93,10 @@ class NetworkPolicyTests(object):
                 "configurations/network-policy/expected-generated-network-policy/deployment-nginx-basic.json",
             ],
             helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
-                         statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+                         "storage.forceVirtualCrds": "true",
+                         statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s',
+                         statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'
+                         }
         )
 
     @staticmethod
@@ -105,7 +112,10 @@ class NetworkPolicyTests(object):
                 "configurations/network-policy/expected-generated-network-policy/busybox.json",
             ],
             helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
-                         statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+                         "storage.forceVirtualCrds": "true",
+                         statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s',
+                         statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'
+                         }
         )
 
     @staticmethod
@@ -123,7 +133,10 @@ class NetworkPolicyTests(object):
                 "configurations/network-policy/expected-generated-network-policy/busybox-known-server.json",
             ],
             helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
-                         statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s', statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'}
+                         "storage.forceVirtualCrds": "true",
+                         statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s',
+                         statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'
+                         }
         )
 
     @staticmethod


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a `"server": ""` key-value pair to the `helm_kwargs` dictionary in several network policy test functions to enhance configuration.
- Improved the formatting of the `helm_kwargs` dictionary for better readability and consistency across the test cases.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_policy_tests.py</strong><dd><code>Add server key to helm_kwargs in network policy tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/network_policy_tests.py

<li>Added <code>"server": ""</code> to <code>helm_kwargs</code> in multiple test functions.<br> <li> Improved consistency in formatting of <code>helm_kwargs</code> dictionary.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/490/files#diff-03dd73b12b9cb4b72ff0f10f170c23e9a5610dec8b50a6effe2e6ebb74891cbb">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information