### PR TITLE
fix: correct spelling of 'compliance' in alert notification check

### DIFF
--- a/tests_scripts/users_notifications/alert_notifications.py
+++ b/tests_scripts/users_notifications/alert_notifications.py
@@ -115,7 +115,7 @@ def assert_misconfiguration_message_sent(messages, cluster):
     found = 0
     for message in messages:
         message_string = str(message)
-        if "Your complaince score has decreased" in message_string and cluster in message_string:
+        if "Your compliance score has decreased" in message_string and cluster in message_string:
             found += 1
     assert found == 1, f"expected to have exactly one new misconfiguration message, found {found}"
 


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Corrected the spelling of 'compliance' in the alert notification check within the `assert_misconfiguration_message_sent` function.
- Ensured that the alert notification correctly identifies the compliance score message.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alert_notifications.py</strong><dd><code>Fix spelling error in alert notification check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/users_notifications/alert_notifications.py

<li>Corrected the spelling of 'compliance' in a string within the code.<br> <li> Ensured the alert notification check uses the correct spelling.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/492/files#diff-060c88bdcfa726da38c03b70cd0a8200d036919e36d7aae93d871504ac2d8ec5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information