### PR TITLE
revert func return

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -2430,7 +2430,7 @@ class ControlPanelAPI(object):
             raise Exception(
                 'Error accessing dashboard. Request: get_security_risks_list "%s" (code: %d, message: %s)' % (
                     self.customer, r.status_code, r.text))
-        return r.text
+        return r
     
     def get_security_risks_severities(self, cluster_name=None, namespace=None, security_risk_ids=[]):
         params = {"customerGUID": self.selected_tenant_id}

--- a/tests_scripts/workflows/jira_workflows.py
+++ b/tests_scripts/workflows/jira_workflows.py
@@ -82,6 +82,7 @@ class WorkflowsJiraNotifications(Workflows):
     
     def assert_jira_tickets_was_created(self, cluster_name, security_risk_ids, ):
         r = self.backend.get_security_risks_list(cluster_name=cluster_name, security_risk_ids=security_risk_ids)
+        r.text
         self.assert_security_risks_jira_ticket_created(response=r)
         body = {
             "fields": {

--- a/tests_scripts/workflows/jira_workflows.py
+++ b/tests_scripts/workflows/jira_workflows.py
@@ -82,7 +82,7 @@ class WorkflowsJiraNotifications(Workflows):
     
     def assert_jira_tickets_was_created(self, cluster_name, security_risk_ids, ):
         r = self.backend.get_security_risks_list(cluster_name=cluster_name, security_risk_ids=security_risk_ids)
-        r.text
+        r = r.text
         self.assert_security_risks_jira_ticket_created(response=r)
         body = {
             "fields": {

--- a/tests_scripts/workflows/utils.py
+++ b/tests_scripts/workflows/utils.py
@@ -19,12 +19,15 @@ SEVERITIES_HIGH = ["High"]
 # workflow names
 WORKFLOW_NAME = "system_test_workflow"
 UPDATED_WORKFLOW_NAME = "system_test_workflow_updated"
+
 SECURITY_RISKS_WORKFLOW_NAME_TEAMS = "security_risks_workflow_teams"
 SECURITY_RISKS_WORKFLOW_NAME_SLACK = "security_risks_workflow_slack"
 SECURITY_RISKS_WORKFLOW_NAME_JIRA = "security_risks_workflow_jira"
+
 VULNERABILITIES_WORKFLOW_NAME_TEAMS = "vulnerabilities_workflow_teams"
 VULNERABILITIES_WORKFLOW_NAME_SLACK = "vulnerabilities_workflow_slack"
 VULNERABILITIES_WORKFLOW_NAME_JIRA = "vulnerabilities_workflow_jira"
+
 COMPLIANCE_WORKFLOW_NAME_TEAMS = "compliance_workflow_teams"
 COMPLIANCE_WORKFLOW_NAME_SLACK = "compliance_workflow_slack"
 


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Modified the `get_security_risks_list` method in `backend_api.py` to return the full response object instead of just the text.
- Updated the `assert_jira_tickets_was_created` method in `jira_workflows.py` to access the response text.
- Improved readability in `utils.py` by adding spacing between workflow name constants.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Modify return type of get_security_risks_list method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/backend_api.py

<li>Changed the return type of the <code>get_security_risks_list</code> method from <br><code>r.text</code> to <code>r</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/498/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_workflows.py</strong><dd><code>Access response text in assert_jira_tickets_was_created</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/jira_workflows.py

- Accessed `r.text` in `assert_jira_tickets_was_created` method.



</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/498/files#diff-3b973446de7b3c083fe131fb8bccba0c40871d835d07fce4d41fd12c226ca9fb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Improve readability of workflow name constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/utils.py

<li>Added spacing between workflow name constants for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/498/files#diff-c8b4257378337a08fb042c981750de10bebed5c51cf7d9c3874a3a9e3c333409">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information