### PR TITLE
fix the jira test

### DIFF
--- a/tests_scripts/workflows/jira_workflows.py
+++ b/tests_scripts/workflows/jira_workflows.py
@@ -69,7 +69,7 @@ class WorkflowsJiraNotifications(Workflows):
         TestUtil.sleep(NOTIFICATIONS_SVC_DELAY_FIRST_SCAN, "waiting for first scan to be saved in notification service")
                      
         Logger.logger.info('Stage 6: Assert jira tickets was created')
-        self.assert_jira_tickets_was_created(self.cluster, SECURITY_RISKS_ID)
+        self.assert_jira_tickets_was_created(self.cluster)
 
         Logger.logger.info('Stage 7: Cleanup')
         return self.cleanup()
@@ -80,8 +80,8 @@ class WorkflowsJiraNotifications(Workflows):
             self.delete_and_assert_workflow(self.return_workflow_guid(VULNERABILITIES_WORKFLOW_NAME_JIRA + self.cluster))
             return super().cleanup(**kwargs)
     
-    def assert_jira_tickets_was_created(self, cluster_name, security_risk_ids, ):
-        r = self.backend.get_security_risks_list(cluster_name=cluster_name, security_risk_ids=security_risk_ids)
+    def assert_jira_tickets_was_created(self, cluster_name):
+        r = self.backend.get_security_risks_list(cluster_name=cluster_name)
         r = r.text
         self.assert_security_risks_jira_ticket_created(response=r)
         body = {


### PR DESCRIPTION
### **PR Type**
bug_fix, tests


___

### **Description**
- Fixed the Jira test by removing the `security_risk_ids` parameter from the `assert_jira_tickets_was_created` method.
- Updated method calls to align with the new method signature.
- Adjusted the logic to fetch the security risks list without requiring `security_risk_ids`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_workflows.py</strong><dd><code>Fix Jira test by updating method parameters and calls</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/jira_workflows.py

<li>Removed <code>security_risk_ids</code> parameter from <br><code>assert_jira_tickets_was_created</code> method.<br> <li> Updated method calls to reflect the removal of the parameter.<br> <li> Adjusted the logic to fetch security risks list without <br><code>security_risk_ids</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/500/files#diff-3b973446de7b3c083fe131fb8bccba0c40871d835d07fce4d41fd12c226ca9fb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information