### PR TITLE
update image gb-frontend for synchronizer test

### DIFF
--- a/configurations/k8s_workloads/synchronizer/replicaset.yaml
+++ b/configurations/k8s_workloads/synchronizer/replicaset.yaml
@@ -17,4 +17,4 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend@sha256:cbc8ef4b0a2d0b95965e0e7dc8938c270ea98e34ec9d60ea64b2d5f2df2dfbbf
+        image: gcr.io/google-samples/gb-frontend@sha256:a908df8486ff66f2c4daa0d3d8a2fa09846a1fc8efd65649c0109695c7c5cbff


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the image tag for the `php-redis` container in the Kubernetes replicaset configuration.
- Changed the SHA256 hash for the `gb-frontend` image to ensure the synchronizer test uses the correct version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>replicaset.yaml</strong><dd><code>Update image tag for php-redis container in replicaset</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/k8s_workloads/synchronizer/replicaset.yaml

<li>Updated the image tag for the <code>php-redis</code> container.<br> <li> Changed the image SHA256 hash for <code>gb-frontend</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/504/files#diff-2333c5e9fb67a3482af8e922949b623237c6dbcf0e3a4477eecd024c42b82e42">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information