### PR TITLE
Update system test mapping to use dummy target repositories for testing

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -1375,8 +1375,8 @@
       "Backend"
     ],
     "target_repositories": [
-      "config-service",
-      "users-notification-service"
+      "config-service-dummy",
+      "users-notification-service-dummy"
     ],
     "description": "testing teams alert channels with compliance and vulnerabilities notifications",
     "skip_on_environment": "staging",
@@ -1387,10 +1387,10 @@
       "Backend"
     ],
     "target_repositories": [
-      "cadashboardbe",
-      "event-ingester-service",
-      "config-service",
-      "users-notification-service"
+      "cadashboardbe-dummy",
+      "event-ingester-service-dummy",
+      "config-service-dummy",
+      "users-notification-service-dummy"
     ],
     "description": "testing slack alert channels with compliance and vulnerabilities notifications",
     "skip_on_environment": "staging",


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `system_test_mapping.json` to replace real target repositories with dummy ones for testing purposes.
- This change affects the `teams_alerts` and `slack_alerts` sections, ensuring that tests do not impact real data.
- The modification is aimed at improving the reliability and safety of system tests by using non-production data.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Use dummy target repositories for alert testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json

<li>Updated target repositories to use dummy repositories for testing.<br> <li> Modified entries under <code>teams_alerts</code> and <code>slack_alerts</code>.<br> <li> Ensured testing environments are not affected by real repository data.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/508/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information