### PR TITLE
remove git commit check

### DIFF
--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -766,12 +766,10 @@ class BaseKubescape(BaseK8S):
     def test_api_version_info(self):
         cli_info = self.kubernetes_obj.get_info_version().to_dict()
         be_info = self.get_version_info(cluster_name=self.kubernetes_obj.get_cluster_name())
-        assert cli_info['git_version'] == be_info['gitVersion'].split(';')[0] and \
-               cli_info['git_commit'] == be_info['gitCommit'], \
-            "cluster {name}: from backend the git-version is {x1}, and git-commit is {y1}." \
-            "from k8s-api the git-version is {x2}, and git-commit is {y2}.".format(
-                name=self.kubernetes_obj.get_cluster_name(), x1=be_info['gitVersion'].split(';')[0],
-                y1=be_info['gitCommit'], x2=cli_info['git_version'], y2=cli_info['git_commit']
+        assert cli_info['git_version'] == be_info['gitVersion'].split(';')[0], \
+            "cluster {name}: from backend the git-version is {x1}." \
+            "from k8s-api the git-version is {x2}.".format(
+                name=self.kubernetes_obj.get_cluster_name(), x1=be_info['gitVersion'].split(';')[0], x2=cli_info['git_version']
             )
 
     @staticmethod


### PR DESCRIPTION
### **PR Type**
tests


___

### **Description**
- Removed the assertion that checked for equality of `git_commit` between CLI and backend in the `test_api_version_info` method.
- Simplified the test to only compare `git_version` between CLI and backend.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_kubescape.py</strong><dd><code>Simplify version info test by removing git commit check</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/kubescape/base_kubescape.py

<li>Removed the check for <code>git_commit</code> equality between CLI and backend.<br> <li> Simplified the assertion in <code>test_api_version_info</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/516/files#diff-576a7629498d80e0394d13997ed798ebc8ed0f7bb881ce43f10c473605d6d66d">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information