### PR TITLE
add cluster and namespace to workflow scope configuration

### DIFF
--- a/tests_scripts/workflows/conf_workflows.py
+++ b/tests_scripts/workflows/conf_workflows.py
@@ -130,7 +130,12 @@ class WorkflowConfigurations(Workflows):
             "updatedBy": "",
             "enabled": True,
             "name": workflow_name,
-            "scope": [],
+            "scope": [
+                {
+                    "cluster": "some-cluster",
+                    "namespace": "some-namespace"
+                }
+            ],
             "conditions": [
                 {
                     "category": "SecurityRisks",
@@ -159,7 +164,12 @@ class WorkflowConfigurations(Workflows):
             "updatedBy": "",
             "enabled": True,
             "name": workflow_name,
-            "scope": [],
+             "scope": [
+                {
+                    "cluster": "some-cluster",
+                    "namespace": "some-namespace"
+                }
+            ],
             "conditions": [
                 {
                     "category": "SecurityRisks",


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the workflow configuration by adding `cluster` and `namespace` to the `scope` for both Slack and Teams workflow bodies.
- This change allows workflows to be more precisely scoped to specific clusters and namespaces.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conf_workflows.py</strong><dd><code>Add cluster and namespace to workflow scope configuration</code></dd></summary>
<hr>

tests_scripts/workflows/conf_workflows.py

<li>Added <code>cluster</code> and <code>namespace</code> to the <code>scope</code> configuration in Slack <br>workflow body.<br> <li> Added <code>cluster</code> and <code>namespace</code> to the <code>scope</code> configuration in Teams <br>workflow body.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/521/files#diff-780a8def7cdc8ddc5e51c20cc81c9109f634cf57947d1563a06a16c4efc6fdac">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information