### PR TITLE
Fix 3

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -1790,7 +1790,8 @@ class ControlPanelAPI(object):
                 'Error accessing dashboard. Request: get registry scan cronjob "%s" (code: %d, message: %s)' % (
                     self.customer, r.status_code, r.text))
         cronjob_list = r.json()
-
+        if cronjob_list is None:
+            cronjob_list = []
         for cj in cronjob_list:
             if cj[statics.CA_VULN_SCAN_CRONJOB_NAME_FILED] == cj_name:
                 return cj

--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -1723,6 +1723,8 @@ class ControlPanelAPI(object):
                 'Error accessing dashboard. Request: get registry scan cronjob list "%s" (code: %d, message: %s)' % (
                     self.customer, r.status_code, r.text))
         cronjob_list = r.json()
+        if cronjob_list is None:
+            cronjob_list = []
         registry_scan_cronjob_list = [cj for cj in cronjob_list if
                                       cj[statics.CA_VULN_SCAN_CRONJOB_CLUSTER_NAME_FILED] == cluster_name]
         self.compare_registry_be_cjs_to_expected(actual_cjs=registry_scan_cronjob_list, expected_cjs=expected_cjs,


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a bug in `get_registry_scan_cronjob` method where `cronjob_list` could be `None`, causing issues in subsequent processing.
- Added a condition to initialize `cronjob_list` to an empty list if it is `None`, ensuring the method can handle empty responses gracefully.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Fix handling of NoneType for cronjob list retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/backend_api.py

<li>Added a check for <code>None</code> to handle cases where <code>cronjob_list</code> is <code>None</code>.<br> <li> Initialized <code>cronjob_list</code> to an empty list if it is <code>None</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/523/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information