### PR TITLE
Remove 'production' environments from skip_on_environment in system t…

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -1647,7 +1647,7 @@
       "event-ingester-service"
     ],
     "description": "Checks workflows slack notifications",
-    "skip_on_environment": "production,production-us",
+    "skip_on_environment": "",
     "owner": "jonathang@armosec.io"
   },
   "teams_notifications_workflows": {
@@ -1660,7 +1660,7 @@
       "event-ingester-service"
     ],
     "description": "Checks workflows teams notifications",
-    "skip_on_environment": "production,production-us",
+    "skip_on_environment": "",
     "owner": "jonathang@armosec.io"
   },
   "jira_notifications_workflows": {
@@ -1673,7 +1673,7 @@
       "event-ingester-service"
     ],
     "description": "Checks workflows jira notifications",
-    "skip_on_environment": "production,production-us",
+    "skip_on_environment": "",
     "owner": "jonathang@armosec.io"
   },
   "workflows_configurations": {
@@ -1687,7 +1687,7 @@
       "event-ingester-service"
     ],
     "description": "Checks workflows configurations",
-    "skip_on_environment": "production,production-us",
+    "skip_on_environment": "",
     "owner": "jonathang@armosec.io"
   }
 }


### PR DESCRIPTION
### **User description**
…est mapping


___

### **PR Type**
enhancement


___

### **Description**
- Removed 'production' and 'production-us' environments from the `skip_on_environment` field in the system test mapping for several workflows.
- This change affects slack, teams, and jira notifications workflows, as well as general workflow configurations.
- The update allows these workflows to be tested in production environments.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Remove production environments from skip_on_environment in workflows</code></dd></summary>
<hr>

system_test_mapping.json

<li>Removed 'production' and 'production-us' from <code>skip_on_environment</code> for <br>multiple workflow configurations.<br> <li> Affected workflows include slack, teams, and jira notifications, as <br>well as workflow configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/529/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information