### PR TITLE
Reduce notification service delay for first scan in workflow scripts

### DIFF
--- a/tests_scripts/workflows/jira_workflows.py
+++ b/tests_scripts/workflows/jira_workflows.py
@@ -1,13 +1,11 @@
 from tests_scripts.workflows.workflows import Workflows
 from tests_scripts.workflows.utils import (
     get_env,
-    NOTIFICATIONS_SVC_DELAY_FIRST_SCAN,
     EXPECTED_CREATE_RESPONSE,
     JIRA_PROVIDER_NAME,
     SECURITY_RISKS,
     SECURITY_RISKS_ID,
     VULNERABILITIES,
-    SEVERITIES_CRITICAL,
     SEVERITIES_HIGH,
     SEVERITIES_MEDIUM,
     VULNERABILITIES_WORKFLOW_NAME_JIRA,

--- a/tests_scripts/workflows/slack_workflows.py
+++ b/tests_scripts/workflows/slack_workflows.py
@@ -3,14 +3,12 @@ from tests_scripts.workflows.workflows import Workflows
 
 from tests_scripts.workflows.utils import (
     get_env,
-    NOTIFICATIONS_SVC_DELAY,
     NOTIFICATIONS_SVC_DELAY_FIRST_SCAN,
     EXPECTED_CREATE_RESPONSE,
     SLACK_CHANNEL_NAME,
     SECURITY_RISKS,
     SECURITY_RISKS_ID,
     VULNERABILITIES,
-    SEVERITIES_CRITICAL,
     SEVERITIES_MEDIUM,
     SEVERITIES_HIGH,
     VULNERABILITIES_WORKFLOW_NAME_SLACK,
@@ -96,7 +94,7 @@ class WorkflowsSlackNotifications(Workflows):
 
         Logger.logger.info('Stage 7: Trigger first scan')
         self.backend.create_kubescape_job_request(cluster_name=self.cluster, framework_list=[self.fw_name])
-        TestUtil.sleep(NOTIFICATIONS_SVC_DELAY, "waiting for first scan to be saved in notification service")
+        TestUtil.sleep(NOTIFICATIONS_SVC_DELAY_FIRST_SCAN, "waiting for first scan to be saved in notification service")
 
         
         Logger.logger.info('Stage 8: Apply second deployment')

--- a/tests_scripts/workflows/teams_workflows.py
+++ b/tests_scripts/workflows/teams_workflows.py
@@ -1,14 +1,12 @@
 from tests_scripts.workflows.workflows import Workflows
 from tests_scripts.workflows.utils import (
     get_env,
-    NOTIFICATIONS_SVC_DELAY,
     NOTIFICATIONS_SVC_DELAY_FIRST_SCAN,
     EXPECTED_CREATE_RESPONSE,
     TEAMS_CHANNEL_NAME,
     SECURITY_RISKS,
     SECURITY_RISKS_ID,
     VULNERABILITIES,
-    SEVERITIES_CRITICAL,
     SEVERITIES_MEDIUM,
     SEVERITIES_HIGH,
     VULNERABILITIES_WORKFLOW_NAME_TEAMS,
@@ -110,7 +108,6 @@ class WorkflowsTeamsNotifications(Workflows):
 
         Logger.logger.info('Stage 11: Trigger second scan')
         self.backend.create_kubescape_job_request(cluster_name=self.cluster, framework_list=[self.fw_name])
-        # TestUtil.sleep(NOTIFICATIONS_SVC_DELAY, "waiting for first scan to be saved in notification service")
         
         Logger.logger.info('Stage 12: Assert all messages sent')
         self.assert_messages_sent(before_test_message_ts, self.cluster)

--- a/tests_scripts/workflows/utils.py
+++ b/tests_scripts/workflows/utils.py
@@ -13,7 +13,7 @@ import time
 
 
 # tests constants
-NOTIFICATIONS_SVC_DELAY_FIRST_SCAN = 7 * 60
+NOTIFICATIONS_SVC_DELAY_FIRST_SCAN = 2 * 60
 NOTIFICATIONS_SVC_DELAY = 7 * 60
 
 # severity levels


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Reduced the notification service delay for the first scan from 7 minutes to 2 minutes.
- Updated Slack workflows to use the reduced delay for the first scan.
- Removed unused imports and cleaned up import statements for better readability in Jira, Slack, and Teams workflow scripts.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_workflows.py</strong><dd><code>Clean up imports in Jira workflows script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/jira_workflows.py

<li>Removed unused import <code>NOTIFICATIONS_SVC_DELAY_FIRST_SCAN</code>.<br> <li> Cleaned up imports for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/530/files#diff-3b973446de7b3c083fe131fb8bccba0c40871d835d07fce4d41fd12c226ca9fb">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>slack_workflows.py</strong><dd><code>Update Slack workflows to reduce first scan delay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/slack_workflows.py

<li>Replaced <code>NOTIFICATIONS_SVC_DELAY</code> with <br><code>NOTIFICATIONS_SVC_DELAY_FIRST_SCAN</code> for first scan delay.<br> <li> Removed unused import <code>NOTIFICATIONS_SVC_DELAY</code>.<br> <li> Cleaned up imports for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/530/files#diff-1d8a6997061d81c57f5da2f627a84789b8c7fb9ef6f18330ff20a81e6959dacb">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>teams_workflows.py</strong><dd><code>Clean up imports in Teams workflows script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/teams_workflows.py

<li>Removed unused import <code>NOTIFICATIONS_SVC_DELAY</code>.<br> <li> Cleaned up imports for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/530/files#diff-88bcef10ffa42274af3cb09f2b0d10ef019f98227e206add7d69bb6e1fad9393">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Reduce notification service delay for first scan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/utils.py

<li>Reduced <code>NOTIFICATIONS_SVC_DELAY_FIRST_SCAN</code> from 7 minutes to 2 <br>minutes.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/530/files#diff-c8b4257378337a08fb042c981750de10bebed5c51cf7d9c3874a3a9e3c333409">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information