### PR TITLE
Revert "Return success status in RegistryChecker start method"

### DIFF
--- a/tests_scripts/registry/registry_connectors.py
+++ b/tests_scripts/registry/registry_connectors.py
@@ -37,7 +37,6 @@ class RegistryChecker(BaseHelm):
         self.cluster = None
 
     def start(self):
-        return statics.SUCCESS, ""
         Logger.logger.info('Stage 1: Install kubescape with helm-chart')
         self.cluster, _ = self.setup(apply_services=False)
         self.install_kubescape()


### PR DESCRIPTION
### **User description**
Reverts armosec/system-tests#532


___

### **PR Type**
Bug fix


___

### **Description**
- Reverts a previous change that was short-circuiting the registry checker functionality
- Restores the original behavior of the `start` method in `RegistryChecker` class:
  * Installs kubescape with helm-chart
  * Sets up the cluster
  * Performs registry connection checks



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry_connectors.py</strong><dd><code>Restore registry checker functionality in start method</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/registry/registry_connectors.py

<li>Removed early return statement <code>return statics.SUCCESS, ""</code> from <code>start</code> <br>method in <code>RegistryChecker</code> class<br> <li> Restored original flow for registry connection checking and kubescape <br>installation<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/533/files#diff-a1624cc5ca4d225581b67cf74ac14a9cb9497ba24260a41724d546ae17ad312b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information