### PR TITLE
extend registries APIs timeouts

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -2185,7 +2185,7 @@ class ControlPanelAPI(object):
         return res
 
     def check_registry(self, payload, provider) -> requests.Response:
-        res = self.post(API_REGISTRY_MANAGEMENT + "/" + provider + "/repositories", cookies=self.selected_tenant_cookie, data=json.dumps(payload))
+        res = self.post(API_REGISTRY_MANAGEMENT + "/" + provider + "/repositories", cookies=self.selected_tenant_cookie, data=json.dumps(payload), timeout=60)
         if not 200 <= res.status_code < 300:
             raise Exception(
                 'Error accessing dashboard. Request: check registry "%s" (code: %d, message: %s)' % (
@@ -2193,7 +2193,7 @@ class ControlPanelAPI(object):
         return res
 
     def create_registry(self, payload, provider) -> requests.Response:
-        res = self.post(API_REGISTRY_MANAGEMENT + "/" + provider, cookies=self.selected_tenant_cookie, data=json.dumps(payload))
+        res = self.post(API_REGISTRY_MANAGEMENT + "/" + provider, cookies=self.selected_tenant_cookie, data=json.dumps(payload), timeout=60)
         if not 200 <= res.status_code < 300:
             raise Exception(
                 'Error accessing dashboard. Request: create registry "%s" (code: %d, message: %s)' % (
@@ -2217,7 +2217,7 @@ class ControlPanelAPI(object):
         return res
 
     def update_registry(self, payload, provider, guid) -> requests.Response:
-        res = self.put(API_REGISTRY_MANAGEMENT + "/" + provider + "/" + guid, cookies=self.selected_tenant_cookie, data=json.dumps(payload))
+        res = self.put(API_REGISTRY_MANAGEMENT + "/" + provider + "/" + guid, cookies=self.selected_tenant_cookie, data=json.dumps(payload), timeout=60)
         if not 200 <= res.status_code < 300:
             raise Exception(
                 'Error accessing dashboard. Request: update registry "%s" (code: %d, message: %s)' % (


### PR DESCRIPTION
### **User description**
Signed-off-by: refaelm <refaelm@armosec.io>


___

### **PR Type**
Enhancement


___

### **Description**
- Added 60-second timeout parameter to registry management API endpoints to prevent indefinite waiting
- Enhanced three registry-related methods with timeout configuration:
  * check_registry()
  * create_registry()
  * update_registry()
- Improves reliability and responsiveness of registry operations



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Add timeout parameters to registry API endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/backend_api.py

<li>Added 60-second timeout parameter to registry-related API calls<br> <li> Modified methods: check_registry(), create_registry(), and <br>update_registry()<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/534/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information