### PR TITLE
Return success status in RegistryChecker start method

### DIFF
--- a/tests_scripts/registry/registry_connectors.py
+++ b/tests_scripts/registry/registry_connectors.py
@@ -37,6 +37,7 @@ class RegistryChecker(BaseHelm):
         self.cluster = None
 
     def start(self):
+        return statics.SUCCESS, ""
         Logger.logger.info('Stage 1: Install kubescape with helm-chart')
         self.cluster, _ = self.setup(apply_services=False)
         self.install_kubescape()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Modified `RegistryChecker.start()` method to immediately return success status instead of performing registry checks
- Added return statement `return statics.SUCCESS, ""` at the beginning of the method
- Note: This change makes the original registry checking functionality unreachable



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry_connectors.py</strong><dd><code>Modify registry checker start method return value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/registry/registry_connectors.py

<li>Added early return statement with success status and empty string<br> <li> Original registry checking functionality is now unreachable<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/535/files#diff-a1624cc5ca4d225581b67cf74ac14a9cb9497ba24260a41724d546ae17ad312b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information