### PR TITLE
Add jiraCollaborationGUID parameter to workflow body builders for Jir…

### DIFF
--- a/tests_scripts/workflows/jira_workflows.py
+++ b/tests_scripts/workflows/jira_workflows.py
@@ -49,9 +49,9 @@ class WorkflowsJiraNotifications(Workflows):
         
                 
         Logger.logger.info("Stage 1: Create new workflows")
-        workflow_body = self.build_securityRisk_workflow_body(name=SECURITY_RISKS_WORKFLOW_NAME_JIRA + self.cluster, severities=SEVERITIES_MEDIUM, siteId=get_env("JIRA_SITE_ID"), projectId=get_env("JIRA_PROJECT_ID"), cluster=self.cluster, namespace=self.namespace, category=SECURITY_RISKS, securityRiskIDs=SECURITY_RISKS_ID, issueTypeId=get_env("JIRA_ISSUE_TYPE_ID"))
+        workflow_body = self.build_securityRisk_workflow_body(name=SECURITY_RISKS_WORKFLOW_NAME_JIRA + self.cluster, severities=SEVERITIES_MEDIUM, jiraCollaborationGUID=get_env("JIRA_COLLABORATION_GUID"), siteId=get_env("JIRA_SITE_ID"), projectId=get_env("JIRA_PROJECT_ID"), cluster=self.cluster, namespace=self.namespace, category=SECURITY_RISKS, securityRiskIDs=SECURITY_RISKS_ID, issueTypeId=get_env("JIRA_ISSUE_TYPE_ID"))
         self.create_and_assert_workflow(workflow_body, EXPECTED_CREATE_RESPONSE, update=False)
-        workflow_body = self.build_vulnerabilities_workflow_body(name=VULNERABILITIES_WORKFLOW_NAME_JIRA + self.cluster, severities=SEVERITIES_HIGH, siteId=get_env("JIRA_SITE_ID"), projectId=get_env("JIRA_PROJECT_ID"), cluster=self.cluster, namespace=self.namespace, category=VULNERABILITIES, cvss=6, issueTypeId=get_env("JIRA_ISSUE_TYPE_ID"))
+        workflow_body = self.build_vulnerabilities_workflow_body(name=VULNERABILITIES_WORKFLOW_NAME_JIRA + self.cluster, severities=SEVERITIES_HIGH, jiraCollaborationGUID=get_env("JIRA_COLLABORATION_GUID"), siteId=get_env("JIRA_SITE_ID"), projectId=get_env("JIRA_PROJECT_ID"), cluster=self.cluster, namespace=self.namespace, category=VULNERABILITIES, cvss=6, issueTypeId=get_env("JIRA_ISSUE_TYPE_ID"))
         self.create_and_assert_workflow(workflow_body, EXPECTED_CREATE_RESPONSE, update=False)
         before_test_message_ts = time.time()
 
@@ -229,7 +229,7 @@ class WorkflowsJiraNotifications(Workflows):
         print(f"Workflow with name {workflow_name} not found")
         return None
     
-    def build_securityRisk_workflow_body(self, name, severities, siteId,  projectId, cluster, namespace, category, securityRiskIDs, issueTypeId, guid=None):
+    def build_securityRisk_workflow_body(self, name, severities, jiraCollaborationGUID, siteId,  projectId, cluster, namespace, category, securityRiskIDs, issueTypeId, guid=None):
         workflow_body = { 
             "guid": guid,
             "updatedTime": "",
@@ -257,6 +257,7 @@ class WorkflowsJiraNotifications(Workflows):
                     "provider": "jira",
                     "jiraTicketIdentifiers": [
                         {
+                            "collaborationGUID": jiraCollaborationGUID,
                             "siteId": siteId,
                             "projectId": projectId,
                             "issueTypeId": issueTypeId,
@@ -268,7 +269,7 @@ class WorkflowsJiraNotifications(Workflows):
         }
         return workflow_body
     
-    def build_vulnerabilities_workflow_body(self, name, severities, siteId, projectId, cluster, namespace, category, cvss, issueTypeId, guid=None):
+    def build_vulnerabilities_workflow_body(self, name, severities, jiraCollaborationGUID, siteId, projectId, cluster, namespace, category, cvss, issueTypeId, guid=None):
         workflow_body = { 
             "guid": guid,
             "updatedTime": "",
@@ -297,6 +298,7 @@ class WorkflowsJiraNotifications(Workflows):
                     "provider": "jira",
                     "jiraTicketIdentifiers": [
                         {
+                            "collaborationGUID": jiraCollaborationGUID,
                             "siteId": siteId,
                             "projectId": projectId,
                             "issueTypeId": issueTypeId,


### PR DESCRIPTION
### **User description**
…a integration


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for JIRA collaboration GUID in workflow body builders:
  - Added `jiraCollaborationGUID` parameter to `build_securityRisk_workflow_body()` and `build_vulnerabilities_workflow_body()`
  - Updated workflow creation calls to pass JIRA collaboration GUID from environment variables
  - Added `collaborationGUID` field to JIRA ticket identifiers configuration
- The changes enable proper JIRA integration by including collaboration identification



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_workflows.py</strong><dd><code>Add JIRA collaboration GUID support to workflow builders</code>&nbsp; </dd></summary>
<hr>

tests_scripts/workflows/jira_workflows.py

<li>Added <code>jiraCollaborationGUID</code> parameter to workflow body builder <br>functions<br> <li> Updated workflow creation calls to include JIRA collaboration GUID <br>from environment<br> <li> Modified JIRA notification configuration to include collaboration GUID <br>field<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/537/files#diff-3b973446de7b3c083fe131fb8bccba0c40871d835d07fce4d41fd12c226ca9fb">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information