### PR TITLE
update target repositories in system_test_mapping.json to use dummy s…

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -164,9 +164,9 @@
       "In cluster"
     ],
     "target_repositories": [
-      "cadashboardbe",
-      "event-ingester-service",
-      "gateway"
+      "cadashboardbe-dummy",
+      "event-ingester-service-dummy",
+      "gateway-dummy"
     ],
     "description": "checks public registry scan capabilities",
     "skip_on_environment": "",
@@ -178,9 +178,9 @@
       "In cluster"
     ],
     "target_repositories": [
-      "cadashboardbe",
-      "event-ingester-service",
-      "gateway"
+      "cadashboardbe-dummy",
+      "event-ingester-service-dummy",
+      "gateway-dummy"
     ],
     "description": "checks public registry scan capabilities",
     "skip_on_environment": "",


### PR DESCRIPTION
### **User description**
…uffix


___

### **PR Type**
Enhancement


___

### **Description**
- Modified target repository names in system test mapping configuration by appending '-dummy' suffix
- Updated repository names for public registry connectivity tests (both regular and excluded)
- Affected repositories: `cadashboardbe`, `event-ingester-service`, `gateway`



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Update test repository names with dummy suffix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json

<li>Updated target repositories names by adding '-dummy' suffix to <br>'cadashboardbe', 'event-ingester-service', and 'gateway'<br> <li> Changes applied to both regular and excluded public registry <br>connectivity test configurations


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/548/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information