### PR TITLE
Testrunningpods

### DIFF
--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -766,6 +766,8 @@ class BaseK8S(BaseDockerizeTest):
             running_pods = self.get_ready_pods(namespace=namespace, name=name)
             if comp_operator(len(running_pods), replicas):  # and len(running_pods) == len(total_pods):
                 Logger.logger.info(f"all pods are running after {timeout - delta_t} seconds")
+                Logger.logger.info(f"running pods {KubectlWrapper.convert_workload_to_dict(running_pods, f_json=True)}")
+                Logger.logger.info(f"cluster state {KubectlWrapper.convert_workload_to_dict(self.get_all_pods(), f_json=True)}")
                 return
             delta_t = (datetime.now() - start).total_seconds()
             time.sleep(10)

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -767,7 +767,7 @@ class BaseK8S(BaseDockerizeTest):
             if comp_operator(len(running_pods), replicas):  # and len(running_pods) == len(total_pods):
                 Logger.logger.info(f"all pods are running after {timeout - delta_t} seconds")
                 Logger.logger.info(f"running pods {KubectlWrapper.convert_workload_to_dict(running_pods, f_json=True)}")
-                Logger.logger.info(f"cluster state {KubectlWrapper.convert_workload_to_dict(self.get_all_pods(), f_json=True)}")
+                Logger.logger.info(f"cluster state {KubectlWrapper.run_kubectl_command('get pods -A', f_json=True)}")
                 return
             delta_t = (datetime.now() - start).total_seconds()
             time.sleep(10)

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -778,7 +778,7 @@ class BaseK8S(BaseDockerizeTest):
                                    KubectlWrapper.convert_workload_to_dict(non_running_pods, f_json=True, indent=2)))
         # KubectlWrapper.convert_workload_to_dict(total_pods, f_json=True, indent=2)))
         raise Exception("wrong number of pods are running after {} seconds. expected: {}, running: {}, pods:{}"
-                        .format(timeout, replicas, len(running_pods)), running_pods)  # , len(total_pods)))
+                        .format(timeout, replicas, len(running_pods), running_pods))  # , len(total_pods)))
 
     def is_namespace_running(self, namespace):
         for ns in self.kubernetes_obj.client_CoreV1Api.list_namespace().items:

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -765,7 +765,7 @@ class BaseK8S(BaseDockerizeTest):
         while delta_t <= timeout:
             running_pods = self.get_ready_pods(namespace=namespace, name=name)
             if comp_operator(len(running_pods), replicas):  # and len(running_pods) == len(total_pods):
-                Logger.logger.info(f"all pods are running after {timeout - delta_t} seconds")
+                Logger.logger.info(f"all pods are running after {delta_t} seconds")
                 Logger.logger.info(f"running pods {KubectlWrapper.convert_workload_to_dict(running_pods, f_json=True)}")
                 Logger.logger.info(f"cluster state {KubectlWrapper.run_kubectl_command('get pods -A', f_json=True)}")
                 return
@@ -778,7 +778,7 @@ class BaseK8S(BaseDockerizeTest):
                                    KubectlWrapper.convert_workload_to_dict(non_running_pods, f_json=True, indent=2)))
         # KubectlWrapper.convert_workload_to_dict(total_pods, f_json=True, indent=2)))
         raise Exception("wrong number of pods are running after {} seconds. expected: {}, running: {}, pods:{}"
-                        .format(timeout, replicas, len(running_pods), running_pods))  # , len(total_pods)))
+                        .format(delta_t, replicas, len(running_pods), running_pods))  # , len(total_pods)))
 
     def is_namespace_running(self, namespace):
         for ns in self.kubernetes_obj.client_CoreV1Api.list_namespace().items:

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import json
 import operator
 import os
+import subprocess
 import time
 
 # allow support for python 3.10
@@ -767,7 +768,8 @@ class BaseK8S(BaseDockerizeTest):
             if comp_operator(len(running_pods), replicas):  # and len(running_pods) == len(total_pods):
                 Logger.logger.info(f"all pods are running after {delta_t} seconds")
                 Logger.logger.info(f"running pods {KubectlWrapper.convert_workload_to_dict(running_pods, f_json=True)}")
-                Logger.logger.info(f"cluster state {KubectlWrapper.run_kubectl_command('get pods -A', f_json=True)}")
+                result = subprocess.run("kubectl get pods -A", timeout=300, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                Logger.logger.info(f"cluster state {result}")
                 return
             delta_t = (datetime.now() - start).total_seconds()
             time.sleep(10)

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -767,7 +767,6 @@ class BaseK8S(BaseDockerizeTest):
             running_pods = self.get_ready_pods(namespace=namespace, name=name)
             if comp_operator(len(running_pods), replicas):  # and len(running_pods) == len(total_pods):
                 Logger.logger.info(f"all pods are running after {delta_t} seconds")
-                Logger.logger.info(f"running pods {KubectlWrapper.convert_workload_to_dict(running_pods, f_json=True)}")
                 result = subprocess.run("kubectl get pods -A", timeout=300, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 Logger.logger.info(f"cluster state {result}")
                 return

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -704,7 +704,6 @@ class BaseK8S(BaseDockerizeTest):
         ready_pods =  list(
             filter(lambda pod: not any(container.ready is False for container in pod.status.container_statuses or []),
                    self.get_pods(namespace=namespace, name=name)))
-        Logger.logger.debug(f"ready pods in namespace {namespace}: {ready_pods}")
         return ready_pods
 
     def restart_pods(self, wlid=None, namespace: str = None, name: str = None):
@@ -776,8 +775,8 @@ class BaseK8S(BaseDockerizeTest):
                             format(timeout,
                                    KubectlWrapper.convert_workload_to_dict(non_running_pods, f_json=True, indent=2)))
         # KubectlWrapper.convert_workload_to_dict(total_pods, f_json=True, indent=2)))
-        raise Exception("wrong number of pods are running after {} seconds. expected: {}, running: {}"
-                        .format(timeout, replicas, len(running_pods)))  # , len(total_pods)))
+        raise Exception("wrong number of pods are running after {} seconds. expected: {}, running: {}, pods:{}"
+                        .format(timeout, replicas, len(running_pods)), running_pods)  # , len(total_pods)))
 
     def is_namespace_running(self, namespace):
         for ns in self.kubernetes_obj.client_CoreV1Api.list_namespace().items:

--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -777,7 +777,9 @@ class BaseK8S(BaseDockerizeTest):
         Logger.logger.error("wrong number of pods are running, timeout: {} seconds. non_running_pods: {}".
                             format(timeout,
                                    KubectlWrapper.convert_workload_to_dict(non_running_pods, f_json=True, indent=2)))
-        # KubectlWrapper.convert_workload_to_dict(total_pods, f_json=True, indent=2)))
+        
+        result = subprocess.run("kubectl get pods -A", timeout=300, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        Logger.logger.info(f"cluster state {result}")
         raise Exception("wrong number of pods are running after {} seconds. expected: {}, running: {}, pods:{}"
                         .format(delta_t, replicas, len(running_pods), running_pods))  # , len(total_pods)))
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored pod filtering logic in `get_pods()` method to use clearer list comprehensions instead of nested lambda functions
- Added comprehensive cluster state logging using `kubectl get pods -A` command when verifying pod status
- Fixed incorrect elapsed time reporting in pod readiness verification (was showing remaining time instead of elapsed time)
- Enhanced error messages with more detailed information about running pods and their status
- Improved code readability and maintainability throughout the BaseK8S class
- Added better error handling for edge cases like None pods



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_k8s.py</strong><dd><code>Enhance pod management and logging in Kubernetes base class</code></dd></summary>
<hr>

tests_scripts/kubernetes/base_k8s.py

<li>Improved pod filtering logic with clearer list comprehensions<br> <li> Added cluster state logging using 'kubectl get pods -A'<br> <li> Fixed elapsed time reporting in pod readiness verification<br> <li> Enhanced error messages with more detailed pod information


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/549/files#diff-79b94c674f22539f1ac228368571a90c18903080e3baedc4e3d255c0a7edaf8a">+27/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information