### PR TITLE
Remove logging of not running pods details in BaseK8S class for clean…

### DIFF
--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -807,8 +807,6 @@ class BaseK8S(BaseDockerizeTest):
         
         all_pods_message = self.get_all_pods_printable_details()
         Logger.logger.info(f"cluster states:\n{all_pods_message}") 
-        not_running_pods_message = self.get_all_not_running_pods_describe_details()   
-        Logger.logger.info(f"not running pods details:\n{not_running_pods_message}")
         raise Exception("wrong number of pods are running after {} seconds. expected: {}, running: {}"
                         .format(delta_t, replicas, len(running_pods)))  # , len(total_pods)))
 


### PR DESCRIPTION
### **User description**
…er output


___

### **PR Type**
Enhancement


___

### **Description**
- Remove detailed logging of non-running pods

- Streamline error output in pod verification


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_k8s.py</strong><dd><code>Remove redundant pod status logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/kubernetes/base_k8s.py

<li>Removed logging of non-running pods detailed description<br> <li> Simplified error output by keeping only essential pod status <br>information


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/554/files#diff-79b94c674f22539f1ac228368571a90c18903080e3baedc4e3d255c0a7edaf8a">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information