### PR TITLE
increase the timeout time

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -1976,7 +1976,7 @@ class ControlPanelAPI(object):
     def post_with_ratelimit(self, url, **args):
         # Extract optional parameters with defaults
         rate_limit_retries = args.pop("rate_limit_retries", 1)
-        rate_limit_sleep = args.pop("rate_limit_sleep", 45)
+        rate_limit_sleep = args.pop("rate_limit_sleep", 60)
 
         for attempt in range(1, rate_limit_retries + 1):
             r = self.post(url, **args)
@@ -2007,7 +2007,7 @@ class ControlPanelAPI(object):
 
     def get_with_rate_limit(self, url, **args):
         rate_limit_retries = args.pop("rate_limit_retries", 1)
-        rate_limit_sleep = args.pop("rate_limit_sleep", 45)
+        rate_limit_sleep = args.pop("rate_limit_sleep", 60)
 
         for attempt in range(1, rate_limit_retries + 1):
             r = self.get(url, **args)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Increased the default rate limit sleep duration to 60 seconds.

- Updated both `post_with_ratelimit` and `get_with_rate_limit` methods.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Adjusted rate limit sleep duration in API methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/backend_api.py

<li>Increased the default <code>rate_limit_sleep</code> from 45 to 60 seconds.<br> <li> Updated in both <code>post_with_ratelimit</code> and <code>get_with_rate_limit</code> methods.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/558/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information