### PR TITLE
Increase default rate limit retries from 1 to 3 in backend API methods

### DIFF
--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -1975,7 +1975,7 @@ class ControlPanelAPI(object):
     
     def post_with_ratelimit(self, url, **args):
         # Extract optional parameters with defaults
-        rate_limit_retries = args.pop("rate_limit_retries", 1)
+        rate_limit_retries = args.pop("rate_limit_retries", 3)
         rate_limit_sleep = args.pop("rate_limit_sleep", 60)
 
         for attempt in range(1, rate_limit_retries + 1):
@@ -2006,7 +2006,7 @@ class ControlPanelAPI(object):
         return requests.get(url, **args)
 
     def get_with_rate_limit(self, url, **args):
-        rate_limit_retries = args.pop("rate_limit_retries", 1)
+        rate_limit_retries = args.pop("rate_limit_retries", 3)
         rate_limit_sleep = args.pop("rate_limit_sleep", 60)
 
         for attempt in range(1, rate_limit_retries + 1):


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Increased default rate limit retries from 1 to 3.

- Updated `post_with_ratelimit` and `get_with_rate_limit` methods.

- Improved handling of rate-limited API requests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Adjusted default rate limit retries in API methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/backend_api.py

<li>Changed default <code>rate_limit_retries</code> from 1 to 3.<br> <li> Updated both <code>post_with_ratelimit</code> and <code>get_with_rate_limit</code> methods.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/570/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information