### PR TITLE
remove redundant parameter from vulnerability retrieval in Jira workf…

### DIFF
--- a/tests_scripts/workflows/jira_workflows.py
+++ b/tests_scripts/workflows/jira_workflows.py
@@ -116,7 +116,7 @@ class WorkflowsJiraNotifications(Workflows):
                     found_sr = True
                 
                 if not found_vuln:
-                    response_vuln = self.backend.get_vulns_v2(body=vuln_body, expected_results=1, enrich_tickets=True)
+                    response_vuln = self.backend.get_vulns_v2(body=vuln_body, enrich_tickets=True)
                     self.assert_vulnerability_jira_ticket_created(issues=issues, response=response_vuln, cves=["CVE-2023-27522"])
                     Logger.logger.info("Vulnerability jira ticket created")
                     found_vuln = True


### PR DESCRIPTION
### **User description**
…lows


___

### **PR Type**
Bug fix


___

### **Description**
- Removed redundant parameter `expected_results` from `get_vulns_v2` call.

- Simplified vulnerability retrieval logic in Jira workflows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_workflows.py</strong><dd><code>Simplify vulnerability retrieval logic in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/jira_workflows.py

<li>Removed the <code>expected_results</code> parameter from <code>get_vulns_v2</code> call.<br> <li> Adjusted logic for vulnerability Jira ticket creation.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/576/files#diff-3b973446de7b3c083fe131fb8bccba0c40871d835d07fce4d41fd12c226ca9fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information