### PR TITLE
return success status in RegistryChecker start method

### DIFF
--- a/tests_scripts/registry/registry_connectors.py
+++ b/tests_scripts/registry/registry_connectors.py
@@ -37,6 +37,7 @@ class RegistryChecker(BaseHelm):
         self.cluster = None
 
     def start(self):
+        return statics.SUCCESS, ""
         Logger.logger.info('Stage 1: Install kubescape with helm-chart')
         self.cluster, _ = self.setup(apply_services=False)
         self.install_kubescape()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a success status return in `RegistryChecker.start` method.

- Ensures consistent return values for the `start` method.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry_connectors.py</strong><dd><code>Add success status return to `start` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/registry/registry_connectors.py

<li>Added a return statement with <code>statics.SUCCESS</code> and an empty string.<br> <li> Ensures the <code>start</code> method explicitly returns a success status.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/578/files#diff-a1624cc5ca4d225581b67cf74ac14a9cb9497ba24260a41724d546ae17ad312b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information