### PR TITLE
Revert "Merge pull request #578 from armosec/temp_remove_tst"

### DIFF
--- a/tests_scripts/registry/registry_connectors.py
+++ b/tests_scripts/registry/registry_connectors.py
@@ -37,7 +37,6 @@ class RegistryChecker(BaseHelm):
         self.cluster = None
 
     def start(self):
-        return statics.SUCCESS, ""
         Logger.logger.info('Stage 1: Install kubescape with helm-chart')
         self.cluster, _ = self.setup(apply_services=False)
         self.install_kubescape()


### PR DESCRIPTION
### **User description**
This reverts commit ccc56f0f071820a3aa459cd2db794fbc0020a7b8, reversing changes made to 1fc780c18f2688c4edeaffdee7b72af2bf17398a.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Reverts a previous commit that removed registry tests.

- Restores the `start` method functionality in `registry_connectors.py`.

- Ensures registry connection checks are re-enabled.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry_connectors.py</strong><dd><code>Restore `start` method functionality in registry tests</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/registry/registry_connectors.py

<li>Removed the return statement from the <code>start</code> method.<br> <li> Restored functionality for registry connection checks.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/579/files#diff-a1624cc5ca4d225581b67cf74ac14a9cb9497ba24260a41724d546ae17ad312b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information