### PR TITLE
restore missing tests from mapping used by Kubescape

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -174,6 +174,87 @@
     "skip_on_environment": "",
     "owner": "matthiasb@armosec.io"
   },
+  "scan_nsa": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
+  "scan_custom_framework_scanning_file_scope_testing": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
+  "scan_custom_framework_scanning_cluster_scope_testing": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
+  "scan_custom_framework_scanning_cluster_and_file_scope_testing": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
+  "scan_mitre": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
+  "scan_repository": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
+  "scan_local_file": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
+  "scan_local_glob_files": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
+  "scan_local_list_of_files": {
+    "target": [
+      "CLI"
+    ],
+    "target_repositories": [],
+    "description": "used by Kubescape",
+    "skip_on_environment": "",
+    "owner": "amirm@armosec.io"
+  },
   "scan_nsa_and_submit_to_backend": {
     "target": [
       "CLI",


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Added multiple test mappings used by Kubescape.

- Included tests for various scanning scenarios (e.g., NSA, MITRE).

- Enhanced test coverage for CLI-based scanning functionalities.

- Assigned ownership for new tests to `amirm@armosec.io`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Add test mappings for Kubescape scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json

<li>Added new test mappings for Kubescape.<br> <li> Included tests for NSA, MITRE, and custom framework scanning.<br> <li> Defined CLI as the target for new tests.<br> <li> Assigned ownership of new tests to <code>amirm@armosec.io</code>.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/581/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information