### PR TITLE
skip google registry check

### DIFF
--- a/tests_scripts/registry/registry_connectors.py
+++ b/tests_scripts/registry/registry_connectors.py
@@ -22,11 +22,11 @@ REGISTRY_PROVIDERS: List[Dict[str, any]] = [
         "secret_field_name": "accessToken",
         "secret_value_env_var": "AZURE_REGISTRY_ACCESS_TOKEN",
     },
-    {
-        "provider": "google",
-        "secret_field_name": "key",
-        "secret_value_env_var": "GOOGLE_REGISTRY_KEY",
-    },
+    # {
+    #     "provider": "google",
+    #     "secret_field_name": "key",
+    #     "secret_value_env_var": "GOOGLE_REGISTRY_KEY",
+    # },
 ]
 
 class RegistryChecker(BaseHelm):


### PR DESCRIPTION
### **User description**
Signed-off-by: refaelm <refaelm@armosec.io>


___

### **PR Type**
Bug fix


___

### **Description**
- Commented out Google registry configuration in the registry connectors.

- Prevents Google registry checks from being executed.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry_connectors.py</strong><dd><code>Disable Google registry configuration in connectors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/registry/registry_connectors.py

<li>Commented out the configuration for Google registry.<br> <li> Removed Google registry from active checks.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/590/files#diff-a1624cc5ca4d225581b67cf74ac14a9cb9497ba24260a41724d546ae17ad312b">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>