### PR TITLE
add sleep to avoid missing syncronizer resource in pg

### DIFF
--- a/tests_scripts/registry/registry_connectors.py
+++ b/tests_scripts/registry/registry_connectors.py
@@ -40,6 +40,7 @@ class RegistryChecker(BaseHelm):
         Logger.logger.info('Stage 1: Install kubescape with helm-chart')
         self.cluster, _ = self.setup(apply_services=False)
         self.install_kubescape()
+        TestUtil.sleep(10)
         Logger.logger.info('Stage 2: Check registries connection')
         self.check_registries_connection(self.cluster)
         Logger.logger.info('Stage 3: Check quay.io registry CRUD operations')


### PR DESCRIPTION
### **User description**
Signed-off-by: refaelm <refaelm@armosec.io>


___

### **PR Type**
Bug fix


___

### **Description**
- Added a sleep delay to ensure synchronizer resource availability.

- Updated test script for registry connectors to improve reliability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry_connectors.py</strong><dd><code>Add sleep delay in registry connectors test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/registry/registry_connectors.py

<li>Added a sleep delay of 10 seconds.<br> <li> Ensured proper synchronization before checking registry connections.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/592/files#diff-a1624cc5ca4d225581b67cf74ac14a9cb9497ba24260a41724d546ae17ad312b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>