### PR TITLE
Update assertion in CSPM test to check for 'guid' in response

### DIFF
--- a/tests_scripts/accounts/cspm.py
+++ b/tests_scripts/accounts/cspm.py
@@ -202,7 +202,7 @@ class CSPM(Accounts):
         assert failed == expect_failure, f"expected_failure is {expect_failure}, but failed is {failed}, body used: {body}"
 
         if not expect_failure:
-            assert "Cloud account created" in res, f"Cloud account was not created, body used: {body}"
+            assert "guid" in res, f"guid not in {res}"
             
     
     def validate_accounts_cloud_list_cspm(self, cloud_account_name:str, arn:str):


### PR DESCRIPTION
### **PR Type**
Tests, Bug fix


___

### **Description**
- Updated CSPM test assertion to check for `guid` in response.

- Improved validation logic for cloud account creation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cspm.py</strong><dd><code>Update assertion logic in CSPM test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/accounts/cspm.py

<li>Modified assertion to check for <code>guid</code> in the response.<br> <li> Replaced previous check for "Cloud account created" in response.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/601/files#diff-361628c2c0b71a324a8ccbb4fda748fe11c647b66eb312efbef22fa1cf761feb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>