### PR TITLE
Remove 'cadashboardbe' from target repositories in system test mapping

### DIFF
--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -133,7 +133,6 @@
       "CLI"
     ],
     "target_repositories": [
-      "cadashboardbe"
     ],
     "description": "",
     "skip_on_environment": "",


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed `cadashboardbe` from `target_repositories` in system test mapping.

- Simplified the configuration for `scan_with_exceptions`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Removed `cadashboardbe` from target repositories list</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json

<li>Removed <code>cadashboardbe</code> from the <code>target_repositories</code> list under <br><code>scan_with_exceptions</code>.<br> <li> No additions or other modifications were made.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/602/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>