### PR TITLE
Update get_stack_output_role_arn method to return ArmoRoleArn

### DIFF
--- a/infrastructure/aws.py
+++ b/infrastructure/aws.py
@@ -80,7 +80,7 @@ class CloudFormationManager:
             raise e
 
     def get_stack_output_role_arn(self):
-        return self.get_stack_output("RoleArn")
+        return self.get_stack_output("ArmoRoleArn")
     
     def get_stack_output(self, output_key):
         try:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated `get_stack_output_role_arn` to return `ArmoRoleArn`.

- Fixed potential issue with incorrect stack output key.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws.py</strong><dd><code>Corrected stack output key in `get_stack_output_role_arn`</code></dd></summary>
<hr>

infrastructure/aws.py

<li>Updated <code>get_stack_output_role_arn</code> to return <code>ArmoRoleArn</code>.<br> <li> Replaced incorrect output key <code>RoleArn</code> with <code>ArmoRoleArn</code>.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/603/files#diff-5c1ba1ea6177304d587a99898a365f9449aa91fd752a9fa0e5b1d003b8ebb363">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>