### PR TITLE
Update delete_cluster_from_backend method to default confirm_deletion…

### DIFF
--- a/tests_scripts/kubernetes/base_k8s.py
+++ b/tests_scripts/kubernetes/base_k8s.py
@@ -198,7 +198,7 @@ class BaseK8S(BaseDockerizeTest):
         except Exception as e:
             pass
 
-    def delete_cluster_from_backend(self, confirm_deletion: bool = True) -> bool:
+    def delete_cluster_from_backend(self, confirm_deletion: bool = False) -> bool:
         if self.cluster_deleted:
             return True
 
@@ -231,6 +231,8 @@ class BaseK8S(BaseDockerizeTest):
             Logger.logger.info("Cluster was deleted successfully '{}'".format(self.kubernetes_obj.get_cluster_name()))
 
             self.cluster_deleted = True
+        else:
+            Logger.logger.info("skipping cluster deletion confirmation")
         return True
 
     def apply_secret(self, **kwargs):


### PR DESCRIPTION
### **User description**
… to False and log skipped confirmation


___

### **PR Type**
Enhancement


___

### **Description**
- Updated `delete_cluster_from_backend` to default `confirm_deletion` to False.

- Added logging for skipped cluster deletion confirmation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_k8s.py</strong><dd><code>Modify `delete_cluster_from_backend` default behavior and logging.</code></dd></summary>
<hr>

tests_scripts/kubernetes/base_k8s.py

<li>Changed default value of <code>confirm_deletion</code> to False.<br> <li> Added logging to indicate skipped cluster deletion confirmation.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/607/files#diff-79b94c674f22539f1ac228368571a90c18903080e3baedc4e3d255c0a7edaf8a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>