### PR TITLE
Raise exception when failing to create Teams channel in workflows

### DIFF
--- a/tests_scripts/workflows/teams_workflows.py
+++ b/tests_scripts/workflows/teams_workflows.py
@@ -157,6 +157,7 @@ class WorkflowsTeamsNotifications(Workflows):
             if "already exists" in str(e):
                 Logger.logger.info("Teams channel already exists")
                 return
+            raise e
         
         assert r == "Teams channel created", f"Expected 'Teams channel created', but got {r['response']}"
         


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added exception raising for unexpected errors in Teams channel creation.

- Improved error handling in `create_webhook` method.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>teams_workflows.py</strong><dd><code>Enhanced error handling in Teams workflows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/teams_workflows.py

<li>Added a <code>raise e</code> statement for unexpected exceptions.<br> <li> Ensured proper error handling when creating Teams channels.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/608/files#diff-88bcef10ffa42274af3cb09f2b0d10ef019f98227e206add7d69bb6e1fad9393">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>