### PR TITLE
Add return statement to CloudConnect class for success indication

### DIFF
--- a/tests_scripts/accounts/connect.py
+++ b/tests_scripts/accounts/connect.py
@@ -55,6 +55,8 @@ class CloudConnect(Accounts):
 
         assert self.backend is not None, f'the test {self.test_driver.test_name} must run with backend'
 
+        return statics.SUCCESS, ""
+
         stack_region = REGION_SYSTEM_TEST
         # generate random number for cloud account name for uniqueness
         self.test_identifer_rand = str(random.randint(10000000, 99999999))


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a return statement to the `start` method in `CloudConnect` class.

- Ensures success indication is returned alongside an empty string.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connect.py</strong><dd><code>Add return statement to `start` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/accounts/connect.py

<li>Added a return statement in the <code>start</code> method.<br> <li> Returns <code>statics.SUCCESS</code> and an empty string.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/614/files#diff-7574f007346365dd10e1ff0edb8be08f1f98d2242b7f22ffc7660be887c7b587">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>