### PR TITLE
add conditional check for skip_apis_validation in CloudConnect discon…

### DIFF
--- a/tests_scripts/accounts/connect.py
+++ b/tests_scripts/accounts/connect.py
@@ -127,13 +127,14 @@ class CloudConnect(Accounts):
         Logger.logger.info('Stage 9: Connect cadr existing account')
         self.connect_cadr_existing_account(stack_region, self.cadr_stack_name_second, cloud_account_guid, log_location)
 
-        Logger.logger.info('Stage 10: disconnect the cspm account')
-        self.disconnect_cspm_account_without_deleting_cloud_account(self.cspm_stack_name,cloud_account_guid ,test_arn)
-        self.tested_stacks.remove(self.cspm_stack_name)
+        if not self.skip_apis_validation:
+            Logger.logger.info('Stage 10: disconnect the cspm account')
+            self.disconnect_cspm_account_without_deleting_cloud_account(self.cspm_stack_name,cloud_account_guid ,test_arn)
+            self.tested_stacks.remove(self.cspm_stack_name)
 
-        Logger.logger.info('Stage 11: return the cspm stack after disconnect')
-        new_arn =self.create_stack_cspm(self.cspm_stack_name, template_url, parameters)
-        assert new_arn == test_arn ,f"excepted the arns to be the same but got old:{test_arn} and new:{new_arn}"
+            Logger.logger.info('Stage 11: return the cspm stack after disconnect')
+            new_arn =self.create_stack_cspm(self.cspm_stack_name, template_url, parameters)
+            assert new_arn == test_arn ,f"excepted the arns to be the same but got old:{test_arn} and new:{new_arn}"
 
         Logger.logger.info('Stage 12: Delete and validate feature cspm when cspm is first')
         self.delete_and_validate_feature(cloud_account_guid, CSPM_FEATURE_NAME)


### PR DESCRIPTION
### **User description**
…nect process


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a conditional check for `skip_apis_validation` in the disconnect process.

- Ensured `disconnect_cspm_account_without_deleting_cloud_account` and stack recreation are skipped when validation is disabled.

- Improved logging to reflect conditional execution of disconnect and stack recreation steps.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connect.py</strong><dd><code>Add conditional logic for <code>skip_apis_validation</code> in disconnect process</code></dd></summary>
<hr>

tests_scripts/accounts/connect.py

<li>Added a conditional check for <code>skip_apis_validation</code> to control the <br>execution of disconnect and stack recreation steps.<br> <li> Modified logging to reflect conditional execution.<br> <li> Ensured stack removal and recreation are skipped when validation is <br>disabled.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/633/files#diff-7574f007346365dd10e1ff0edb8be08f1f98d2242b7f22ffc7660be887c7b587">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>