### PR TITLE
fix: remove unused import for webhook alert notifications in runtime …

### DIFF
--- a/configurations/system/tests_cases/runtime_tests.py
+++ b/configurations/system/tests_cases/runtime_tests.py
@@ -1,7 +1,7 @@
 import inspect
 
 from tests_scripts.runtime.alerts import enrich_slack_alert_notifications, enrich_teams_alert_notifications
-from tests_scripts.users_notifications.alert_notifications import enrich_slack_alert_channel, enrich_teams_alert_channel, get_messages_from_slack_channel, get_messages_from_teams_channel
+from tests_scripts.users_notifications.alert_notifications import get_messages_from_slack_channel, get_messages_from_teams_channel
 from .structures import KubescapeConfiguration, TestConfiguration
 from os.path import join
 from systest_utils.statics import DEFAULT_DEPLOYMENT_PATH


### PR DESCRIPTION
### **User description**
…tests


___

### **PR Type**
Bug fix


___

### **Description**
- Removed unused imports in `runtime_tests.py`.

- Improved code clarity by cleaning up imports.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime_tests.py</strong><dd><code>Cleaned up unused imports in runtime tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/runtime_tests.py

<li>Removed unused imports for alert notifications.<br> <li> Retained only necessary imports for Slack and Teams messages.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/639/files#diff-9c1946b453a24f271acd0baadfeddc2605cc63db31b2c3f82e4d1f703d68f72c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>