### PR TITLE
fix: update notes for HTTP/2 Rapid Reset Vulnerability details

### DIFF
--- a/configurations/expected-result/V2_VIEWS/kev_vulan.json
+++ b/configurations/expected-result/V2_VIEWS/kev_vulan.json
@@ -2,5 +2,5 @@
     "dateAdded": "2023-10-10",
     "dueDate": "2023-10-31",
     "knownRansomwareCampaignUse": "Unknown",
-    "notes": "This vulnerability affects a common open-source component, third-party library, or protocol used by different products. For more information, please see: CVE: Common Vulnerabilities and Exposures; https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/;  https://nvd.nist.gov/vuln/detail/CVE-2023-44487"
+    "notes": "This vulnerability affects a common open-source component, third-party library, or protocol used by different products. For more information, please see: HTTP/2 Rapid Reset Vulnerability, CVE-2023-44487 | CISA: https://www.cisa.gov/news-events/alerts/2023/10/10/http2-rapid-reset-vulnerability-cve-2023-44487; https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/;  https://nvd.nist.gov/vuln/detail/CVE-2023-44487"
 }


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Updated the `notes` field in `kev_vulan.json` to include a more detailed reference for the HTTP/2 Rapid Reset Vulnerability.

- Added a link to the CISA alert for CVE-2023-44487.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kev_vulan.json</strong><dd><code>Enhanced `notes` with detailed vulnerability references</code>&nbsp; &nbsp; </dd></summary>
<hr>

configurations/expected-result/V2_VIEWS/kev_vulan.json

<li>Updated the <code>notes</code> field with a more detailed description.<br> <li> Added a reference to the CISA alert for CVE-2023-44487.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/650/files#diff-9cfa9a59823b615c9ae9bcaa183c2c9daba705ba48296eab8b2c896716f0b758">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>