### PR TITLE
SBOM test

### DIFF
--- a/configurations/system/tests_cases/ks_microservice_test.py
+++ b/configurations/system/tests_cases/ks_microservice_test.py
@@ -2,6 +2,7 @@ import inspect
 
 from .structures import TestConfiguration
 from systest_utils import statics
+from os.path import join
 
 
 
@@ -21,6 +22,16 @@ class KSMicroserviceTests(object):
         )
 
 
+    @staticmethod
+    def sbom_test():
+         from tests_scripts.helm.ks_microservice import ScanSBOM
+
+         return TestConfiguration(
+                name=inspect.currentframe().f_code.co_name,
+                test_obj=ScanSBOM,
+                deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "redis_sleep_long"),
+
+         )
 
     @staticmethod
     def attackchains_all():

--- a/infrastructure/backend_api.py
+++ b/infrastructure/backend_api.py
@@ -2152,12 +2152,11 @@ class ControlPanelAPI(object):
         return self.post_list_request(url, body, expected_results, params=params)
 
     def get_vuln_v2_components(self, body: dict, expected_results: int = 0, scope: str = None, enrich_tickets=False):
-        url = API_VULNERABILITY_V2_IMAGE
         params = {}
         if scope:
-            params = {"scope": scope}
+            params["scope"] = scope
         if not enrich_tickets:
-            params = {"enrichTickets": "false"}
+            params["enrichTickets"] = "false"
         return self.post_list_request(API_VULNERABILITY_V2_COMPONENT, body, expected_results, params=params)
 
     def get_posture_resources_highlights(self, body: dict):

--- a/system_test_mapping.json
+++ b/system_test_mapping.json
@@ -1227,5 +1227,18 @@
   "description": "testing basic incident presented",
   "skip_on_environment": "",
   "owner": "eranm@armosec.io"
-}
+},
+"sbom_test": {
+    "target": [
+      "In cluster",
+      "Backend"
+    ],
+    "target_repositories": [
+      "cadashboardbe",
+      "event-ingester-service"
+    ],
+    "description": "testing basic incident presented",
+    "skip_on_environment": "production,production-us",
+    "owner": "eranm@armosec.io"
+  }
 }

--- a/systest_utils/statics.py
+++ b/systest_utils/statics.py
@@ -270,6 +270,10 @@ HELM_NODE_SBOM_GENERATION = "capabilities.nodeSbomGeneration"
 HELM_NODE_SBOM_GENERATION_ENABLED = "enable"
 HELM_NODE_SBOM_GENERATION_DISABLED = "disable"
 
+HELM_SYNC_SBOM = "capabilities.syncSBOM"
+HELM_SYNC_SBOM_ENABLED = "enable"
+HELM_SYNC_SBOM_DISABLED = "disable"
+
 # relevancy feature
 HELM_NETWORK_POLICY_FEATURE = "capabilities.networkPolicyService"
 HELM_NODE_AGENT_LEARNING_PERIOD = "nodeAgent.config.learningPeriod"


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced SBOM scanning test for microservices.
  - Added `ScanSBOM` class to automate SBOM scan via Helm.
  - Integrated SBOM test into microservice test suite.

- Updated system test mapping to include SBOM test configuration.

- Enhanced Helm/statics with SBOM-related constants.

- Fixed parameter handling in backend API vulnerability component retrieval.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Add SBOM scanning logic and validation class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py

<li>Added <code>ScanSBOM</code> class for automated SBOM scanning.<br> <li> Implemented backend result verification for SBOM scan.<br> <li> Integrated Helm installation and deployment logic for SBOM tests.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/654/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>statics.py</strong><dd><code>Add Helm constants for SBOM sync capability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

systest_utils/statics.py

- Introduced SBOM-related Helm constants for configuration.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/654/files#diff-741805bf43ee8065d3c6f32870106551b7a27a6cbc692f403e5da6cbeefeb819">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice_test.py</strong><dd><code>Integrate SBOM test into microservice test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/ks_microservice_test.py

<li>Added <code>sbom_test</code> static method to test suite.<br> <li> Integrated SBOM test configuration using <code>ScanSBOM</code>.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/654/files#diff-d6e0a110181364d760a49881a441fcb09a5131f2c47261bea53f338f5ef8768e">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_test_mapping.json</strong><dd><code>Add SBOM test to system test mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_test_mapping.json

- Added `sbom_test` entry with configuration and metadata.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/654/files#diff-7ac9a8e9fb7431bc23f91250ada3220ba55bdcb91d6a30b72ee1ab242a88e78d">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_api.py</strong><dd><code>Fix parameter handling in vulnerability component API</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/backend_api.py

<li>Fixed parameter dictionary handling in <code>get_vuln_v2_components</code>.<br> <li> Improved robustness for API parameter merging.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/654/files#diff-a386f72e107e19ee1faa1c9946d320d17d3ce39a24ea1cacee998ae67a7db245">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>