### PR TITLE
fix: update expected prices for monthly and yearly subscriptions

### DIFF
--- a/configurations/system/tests_cases/payments_tests.py
+++ b/configurations/system/tests_cases/payments_tests.py
@@ -5,7 +5,7 @@ from .structures import PaymentConfiguration
 # plan names and their price per unit in cents.
 # the name is an internal identifier which is assigned to a stripe priceId object. 
 # The price is the price in cents as defined in Stripe price object.
-EXPECTED_PRICES = [{"name":"MonthlyPriceID","price":3900},{"name":"YearlyPriceID","price":36000}]
+EXPECTED_PRICES = [{"name":"MonthlyPriceID","price":4900},{"name":"YearlyPriceID","price":48000}]
 TEST_STRIPE_CUSTOMER_ID = "cus_NT8XoDsp5Alqwc"
 
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Update expected Stripe prices for monthly and yearly subscriptions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payments_tests.py</strong><dd><code>Update expected Stripe prices for subscription plans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/payments_tests.py

<li>Updated the expected price for <code>MonthlyPriceID</code> from 3900 to 4900 cents<br> <li> Updated the expected price for <code>YearlyPriceID</code> from 36000 to 48000 cents


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/656/files#diff-923d0eda3d83d51cbf3d52112930c9dc8b7992b37c581b4842539ba18162331b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>