### PR TITLE
fix workload name filter

### DIFF
--- a/tests_scripts/helm/jira_integration.py
+++ b/tests_scripts/helm/jira_integration.py
@@ -296,14 +296,12 @@ class JiraIntegration(BaseKubescape, BaseHelm):
             {
                 "cluster": self.cluster,
                 "namespace": self.namespace,
-                "name": "nginx",
+                "workload": "nginx",
                 "kind":"deployment",
             }]}
         wl_list, _ = self.wait_for_report(timeout=600, report_type=self.backend.get_vuln_v2_workloads,
                                               body=body,expected_results=1, enrich_tickets=True) 
         self.vulnWL = wl_list[0]
-        body['innerFilters'][0]['workload'] = "nginx"
-        del body['innerFilters'][0]['name']
 
         Logger.logger.info('get nginx workload image')
         image = self.backend.get_vuln_v2_images(body=body, expected_results=1, enrich_tickets=True)

--- a/tests_scripts/helm/vuln_scan.py
+++ b/tests_scripts/helm/vuln_scan.py
@@ -591,7 +591,7 @@ class VulnerabilityV2ViewsKEV(BaseVulnerabilityScanning):
                 "cluster": cluster,
                 "namespace": namespace,
                 "kind" : "deployment",
-                "name": "mariadb"
+                "workload": "mariadb"
             }]}
         self.wait_for_report(timeout=600, report_type=self.backend.get_vuln_v2_workloads,
                                               body=body,expected_results=1)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix workload name filter in vulnerability report queries

- Replace `name` filter with `workload` in API request bodies

- Ensure correct filtering for `nginx` and `mariadb` workloads


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_integration.py</strong><dd><code>Use `workload` instead of `name` for workload filtering</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/jira_integration.py

<li>Replaced <code>name</code> filter with <code>workload</code> for workload queries<br> <li> Removed redundant filter manipulation for <code>nginx</code><br> <li> Ensured correct filter usage in vulnerability and image queries


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/660/files#diff-5a901f2fef79a9c4f309e5fe5da5f599737904ffbe50627fc852419377b5b64a">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vuln_scan.py</strong><dd><code>Replace `name` with `workload` in vulnerability filter</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/vuln_scan.py

<li>Changed filter key from <code>name</code> to <code>workload</code> for <code>mariadb</code><br> <li> Ensured vulnerability report uses correct filter


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/660/files#diff-288de96b50f4d3d32f61bc4d91633848bd020741853e6416e73f7c9a1ee415e0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>