### PR TITLE
add verification for SBOM scan results in use

### DIFF
--- a/configurations/k8s_workloads/deployments/nginx/nginx.yaml
+++ b/configurations/k8s_workloads/deployments/nginx/nginx.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80

--- a/configurations/system/tests_cases/ks_microservice_test.py
+++ b/configurations/system/tests_cases/ks_microservice_test.py
@@ -29,7 +29,7 @@ class KSMicroserviceTests(object):
          return TestConfiguration(
                 name=inspect.currentframe().f_code.co_name,
                 test_obj=ScanSBOM,
-                deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "redis_sleep_long"),
+                deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "busy_box"),
 
          )
 

--- a/configurations/system/tests_cases/ks_microservice_test.py
+++ b/configurations/system/tests_cases/ks_microservice_test.py
@@ -29,7 +29,7 @@ class KSMicroserviceTests(object):
          return TestConfiguration(
                 name=inspect.currentframe().f_code.co_name,
                 test_obj=ScanSBOM,
-                deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "busy_box"),
+                deployments=join(statics.DEFAULT_DEPLOYMENT_PATH, "nginx"),
 
          )
 

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -1039,7 +1039,6 @@ class ScanSBOM(BaseHelm, BaseKubescape):
     
         component = components[0]
         assert component["name"] == filters["name"], f"expected libcrypto3, got {component['name']}"
-        assert component["packageType"] == "apk", f"expected apk, got {component['packageType']}"
         assert "licenses" in component, "expected licenses, got None"
         assert len(component["licenses"]) > 0, f"expected some licenses, got {component['licenses']}"
         assert "severityStats" in component, "expected severityStats, got None"

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -986,14 +986,14 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         self.install_armo_helm_chart(helm_kwargs=self.helm_kwargs)
         self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=240)
 
-        Logger.logger.info('1. Install deployments in the cluster')
+        Logger.logger.info('2. Install deployments in the cluster')
         current_datetime = datetime.now(timezone.utc)
         workload_objs: list = self.apply_directory(path=self.test_obj[("deployments", None)], namespace=self.namespace)
         self.wait_for_report(self.verify_running_pods, sleep_interval=10, timeout=180, namespace=self.namespace)
 
 
 
-        Logger.logger.info("2. verify SBOM scan results")
+        Logger.logger.info("3. verify SBOM scan results")
         filters = {
             "cluster": self.cluster,
             "namespace": self.namespace,

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -1004,13 +1004,13 @@ class ScanSBOM(BaseHelm, BaseKubescape):
 
 
         Logger.logger.info("4. verify SBOM scan results unique values")
-        self.verify_backend_results_uniquevalues(filters=filters, field="workload", expected_value="redis-sleep")
+        self.verify_backend_results_uniquevalues(filters=filters, field="workload", expected_value="nginx")
 
 
         filters = {
             "cluster": self.cluster,
             "namespace": self.namespace,
-            "workload": "redis-sleep",
+            "workload": "nginx",
         }
 
         Logger.logger.info("5. verify SBOM scan results in use")
@@ -1038,8 +1038,7 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         assert len(components) == 1, f"expected 1 component, got {len(components)}"
     
         component = components[0]
-        assert component["name"] == "libcrypto3", f"expected libcrypto3, got {component['name']}"
-        assert component["version"] == "3.0.8-r0", f"expected 3.0.8-r0, got {component['version']}"
+        assert component["name"] == filters["name"], f"expected libcrypto3, got {component['name']}"
         assert component["packageType"] == "apk", f"expected apk, got {component['packageType']}"
         assert "licenses" in component, "expected licenses, got None"
         assert len(component["licenses"]) > 0, f"expected some licenses, got {component['licenses']}"

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -1063,12 +1063,12 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         filters["isRelevant"] = "Yes"
 
         components = self.backend.get_vuln_v2_components(body=body, scope='component', enrich_tickets=False)
-        assert len(components) > 0, f"expected at least 1 component, got {len(components)}"    
+        assert len(components) > 0, f"expected at least 1 in use component, got {len(components)}"    
        
         filters["isRelevant"] = "No"
 
         components = self.backend.get_vuln_v2_components(body=body, scope='component', enrich_tickets=False)
-        assert len(components) > 0 , f"expected at least 1 component, got {len(components)}"
+        assert len(components) > 0 , f"expected at least 1 not in use component, got {len(components)}"
 
 
     def verify_backend_results_uniquevalues(self, filters, field, expected_value):

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -1035,6 +1035,7 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         }
 
         components = self.backend.get_vuln_v2_components(body=body, scope='component', enrich_tickets=False)
+        assert components != None, "expected components, got None"
         assert len(components) == 1, f"expected 1 component, got {len(components)}"
     
         component = components[0]

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -997,8 +997,8 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         filters = {
             "cluster": self.cluster,
             "namespace": self.namespace,
-            "workload": "redis-sleep",
-            "name": "libcrypto3"
+            "workload": "nginx",
+            "name": "nginx"
         }
         self.wait_for_report(self.verify_backend_results, sleep_interval=10, timeout=180, filters=filters)
 
@@ -1014,7 +1014,7 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         }
 
         Logger.logger.info("5. verify SBOM scan results in use")
-        self.wait_for_report(self.verify_backend_results_in_use, sleep_interval=10, timeout=180, filters=filters)
+        self.wait_for_report(self.verify_backend_results_in_use, sleep_interval=10, timeout=240, filters=filters)
 
         return self.cleanup()
     

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -965,8 +965,8 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         """
         Agenda:
 
-        1. Install deployments in the cluster
-        2. Install kubescape with helm-chart
+        1. Install kubescape with helm-chart
+        2. Install deployments in the cluster
         3. verify SBOM scan results
         4. verify SBOM scan results unique values
         5. verify SBOM scan results in use
@@ -978,20 +978,22 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         self.cluster, self.namespace = self.setup(apply_services=False)
 
 
+
+
+
+        Logger.logger.info("1. Install kubescape with helm-chart")
+        self.add_and_upgrade_armo_to_repo()
+        self.install_armo_helm_chart(helm_kwargs=self.helm_kwargs)
+        self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=240)
+
         Logger.logger.info('1. Install deployments in the cluster')
         current_datetime = datetime.now(timezone.utc)
         workload_objs: list = self.apply_directory(path=self.test_obj[("deployments", None)], namespace=self.namespace)
         self.wait_for_report(self.verify_running_pods, sleep_interval=10, timeout=180, namespace=self.namespace)
 
 
-        Logger.logger.info("2. Install kubescape with helm-chart")
-        self.add_and_upgrade_armo_to_repo()
-        self.install_armo_helm_chart(helm_kwargs=self.helm_kwargs)
-        self.verify_running_pods(namespace=statics.CA_NAMESPACE_FROM_HELM_NAME, timeout=240)
 
-
-
-        Logger.logger.info("3. verify SBOM scan results")
+        Logger.logger.info("2. verify SBOM scan results")
         filters = {
             "cluster": self.cluster,
             "namespace": self.namespace,

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -953,7 +953,7 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         
         # disable node agent capabilities
         self.helm_kwargs = {
-            # statics.HELM_NODE_SBOM_GENERATION: statics.HELM_NODE_SBOM_GENERATION_DISABLED,
+            statics.HELM_NODE_SBOM_GENERATION: statics.HELM_NODE_SBOM_GENERATION_DISABLED,
             statics.HELM_SYNC_SBOM: statics.HELM_SYNC_SBOM_ENABLED,
         }
 

--- a/tests_scripts/helm/ks_microservice.py
+++ b/tests_scripts/helm/ks_microservice.py
@@ -953,7 +953,7 @@ class ScanSBOM(BaseHelm, BaseKubescape):
         
         # disable node agent capabilities
         self.helm_kwargs = {
-            statics.HELM_NODE_SBOM_GENERATION: statics.HELM_NODE_SBOM_GENERATION_DISABLED,
+            # statics.HELM_NODE_SBOM_GENERATION: statics.HELM_NODE_SBOM_GENERATION_DISABLED,
             statics.HELM_SYNC_SBOM: statics.HELM_SYNC_SBOM_ENABLED,
         }
 


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Added verification for SBOM scan results "in use" status.

- Introduced new test method `verify_backend_results_in_use`.

- Updated test workflow to include "in use" SBOM validation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ks_microservice.py</strong><dd><code>Add and integrate SBOM "in use" results verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/ks_microservice.py

<li>Added step to verify SBOM scan results "in use" in the test agenda.<br> <li> Implemented <code>verify_backend_results_in_use</code> method to check components <br>with <code>isRelevant</code> set to "Yes" and "No".<br> <li> Integrated the new verification into the main test flow.<br> <li> Minor formatting and whitespace adjustments.


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/664/files#diff-2227809d59282c5fa57396ee7ebd44649e123348b8674e6e4b1a93d2382bf1d2">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>