### PR TITLE
Increase sleep duration in IncidentsAlerts to 80 seconds to accommoda…

### DIFF
--- a/tests_scripts/runtime/alerts.py
+++ b/tests_scripts/runtime/alerts.py
@@ -116,7 +116,7 @@ class IncidentsAlerts(AlertNotifications, RuntimePoliciesConfigurations):
         Logger.logger.info(
             f'workloads are running, waiting for application profile finalizing before exec into pod {wlids}')
         self.wait_for_report(self.verify_application_profiles, wlids=wlids, namespace=namespace)
-        time.sleep(30)
+        time.sleep(80) # the node agent cache waits 60+ secs before caching profile, needs to update helm chart with value to make it 5 secs
         self.exec_pod(wlid=wlids[0], command="cat /etc/hosts")
 
         Logger.logger.info("Get incidents list")


### PR DESCRIPTION
…te node agent cache update timing. Update helm chart value to reduce cache wait time to 5 seconds in future.