### PR TITLE
only specify "--server" on KS submit

### DIFF
--- a/tests_scripts/kubescape/base_kubescape.py
+++ b/tests_scripts/kubescape/base_kubescape.py
@@ -159,7 +159,7 @@ class BaseKubescape(BaseK8S):
         if "account" in kwargs:
             command.extend(["--account", self.backend.get_customer_guid()])
             env = {"KS_ACCESS_KEY": self.backend.get_access_key()} if self.backend.get_access_key() != "" else {}
-        command.extend(["--server", self.api_url])
+            command.extend(["--server", self.api_url])
 
         Logger.logger.info(" ".join(command))
         status_code, res = TestUtil.run_command(command_args=command,
@@ -237,8 +237,7 @@ class BaseKubescape(BaseK8S):
             command.extend(["--account", self.backend.get_customer_guid()])
             # set the access key with env var until it will be supported as a flag
             env = {"KS_ACCESS_KEY": self.backend.get_access_key()} if self.backend.get_access_key() != "" else {}
-
-        command.extend(["--server", self.api_url])
+            command.extend(["--server", self.api_url])
 
         # first check if artifacts are passed to function
         if "use_artifacts" in kwargs and kwargs['use_artifacts'] != "":


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix conditional server URL specification in Kubescape commands

- Only add `--server` flag when account is specified


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Kubescape Command"] --> B["Account Check"]
  B --> C["Add --server flag"]
  C --> D["Execute Command"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_kubescape.py</strong><dd><code>Conditional server URL flag specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/kubescape/base_kubescape.py

<li>Move <code>--server</code> flag addition inside account conditional blocks<br> <li> Fix indentation to properly scope server URL specification<br> <li> Apply same pattern to both <code>download_policy</code> and <code>scan</code> methods


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/680/files#diff-576a7629498d80e0394d13997ed798ebc8ed0f7bb881ce43f10c473605d6d66d">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>