### PR TITLE
fix expected NN status in network_policy_pod_restarted

### DIFF
--- a/configurations/network-policy/expected-network-neighborhood/deployment-wikijs.json
+++ b/configurations/network-policy/expected-network-neighborhood/deployment-wikijs.json
@@ -14,8 +14,8 @@
       "kubescape.io/workload-name": "wikijs"
     },
     "annotations": {
-      "kubescape.io/completion": "complete",
-      "kubescape.io/status": "ready"
+      "kubescape.io/completion": "partial",
+      "kubescape.io/status": "completed"
     }
   },
   "spec": {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Update NetworkNeighborhood status annotations in test configuration

- Change completion from "complete" to "partial"

- Change status from "ready" to "completed"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Configuration"] -- "update annotations" --> B["NetworkNeighborhood Status"]
  B -- "completion: partial" --> C["Updated Status"]
  B -- "status: completed" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment-wikijs.json</strong><dd><code>Fix NetworkNeighborhood status annotations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighborhood/deployment-wikijs.json

<ul><li>Updated <code>kubescape.io/completion</code> annotation from "complete" to <br>"partial"<br> <li> Updated <code>kubescape.io/status</code> annotation from "ready" to "completed"</ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/698/files#diff-b4b7c4da844c0caf92b7436ab619207113010c65267eb03e3e35ecdfedce1af0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

