### PR TITLE
Revert "fix expected NN status in network_policy_pod_restarted"

### DIFF
--- a/configurations/network-policy/expected-network-neighborhood/deployment-wikijs.json
+++ b/configurations/network-policy/expected-network-neighborhood/deployment-wikijs.json
@@ -14,8 +14,8 @@
       "kubescape.io/workload-name": "wikijs"
     },
     "annotations": {
-      "kubescape.io/completion": "partial",
-      "kubescape.io/status": "completed"
+      "kubescape.io/completion": "complete",
+      "kubescape.io/status": "ready"
     }
   },
   "spec": {


### PR DESCRIPTION
### **User description**
This reverts commit f17d5a755f4f09536d7510d5dfafbb14acfdeacb.


___

### **PR Type**
Bug fix


___

### **Description**
- Revert network neighborhood status annotations to previous values

- Change completion from "partial" to "complete"

- Change status from "completed" to "ready"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Previous Commit"] --> B["Revert Changes"]
  B --> C["Restore Original Status"]
  C --> D["completion: complete"]
  C --> E["status: ready"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment-wikijs.json</strong><dd><code>Revert network neighborhood status annotations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/network-policy/expected-network-neighborhood/deployment-wikijs.json

<ul><li>Revert <code>kubescape.io/completion</code> annotation from "partial" to "complete"<br> <li> Revert <code>kubescape.io/status</code> annotation from "completed" to "ready"</ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/700/files#diff-b4b7c4da844c0caf92b7436ab619207113010c65267eb03e3e35ecdfedce1af0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

