### PR TITLE
fix network_policy_pod_restarted by finishing learning

### DIFF
--- a/configurations/system/tests_cases/network_policy_tests.py
+++ b/configurations/system/tests_cases/network_policy_tests.py
@@ -95,6 +95,7 @@ class NetworkPolicyTests(object):
             helm_kwargs={statics.HELM_NETWORK_POLICY_FEATURE: statics.HELM_RELEVANCY_FEATURE_ENABLED,
                          "storage.forceVirtualCrds": "true",
                          statics.HELM_NODE_AGENT_LEARNING_PERIOD: '30s',
+                         statics.HELM_NODE_AGENT_MAX_LEARNING_PERIOD: '3m',
                          statics.HELM_NODE_AGENT_UPDATE_PERIOD: '10s'
                          }
         )

--- a/systest_utils/statics.py
+++ b/systest_utils/statics.py
@@ -279,6 +279,7 @@ HELM_SYNC_SBOM_DISABLED = "disable"
 # relevancy feature
 HELM_NETWORK_POLICY_FEATURE = "capabilities.networkPolicyService"
 HELM_NODE_AGENT_LEARNING_PERIOD = "nodeAgent.config.learningPeriod"
+HELM_NODE_AGENT_MAX_LEARNING_PERIOD = "nodeAgent.config.maxLearningPeriod"
 HELM_NODE_AGENT_UPDATE_PERIOD = "nodeAgent.config.updatePeriod"
 HELM_RELEVANCY_FEATURE = "capabilities.relevancy"
 HELM_RELEVANCY_FEATURE_ENABLED = "enable"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix network policy pod restart test by adding max learning period configuration

- Adjust timing parameters for better test reliability

- Improve wait periods for node-agent operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Configuration"] --> B["Add Max Learning Period"]
  B --> C["Adjust Wait Times"]
  C --> D["Improve Test Reliability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_policy_tests.py</strong><dd><code>Add max learning period configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configurations/system/tests_cases/network_policy_tests.py

<ul><li>Add <code>HELM_NODE_AGENT_MAX_LEARNING_PERIOD</code> configuration with 3-minute <br>timeout<br> <li> Configure maximum learning period for network policy test</ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/701/files#diff-03dd73b12b9cb4b72ff0f10f170c23e9a5610dec8b50a6effe2e6ebb74891cbb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>network_policy.py</strong><dd><code>Adjust timing and validation parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/helm/network_policy.py

<ul><li>Change wait calculation from learning period to update period<br> <li> Reduce backend validation timeout from 240 to 120 seconds<br> <li> Add spacing for better code readability</ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/701/files#diff-83e690ba62dd64c5e40792cf88ae5cb24ecb8ffeeab4cf257e4dcb661bd9b3c0">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statics.py</strong><dd><code>Add max learning period constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

systest_utils/statics.py

<ul><li>Define new constant <code>HELM_NODE_AGENT_MAX_LEARNING_PERIOD</code><br> <li> Add configuration key for node agent maximum learning period</ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/701/files#diff-741805bf43ee8065d3c6f32870106551b7a27a6cbc692f403e5da6cbeefeb819">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

