### PR TITLE
Refactor get_cspm_link method in Accounts class to use string "true" …

### DIFF
--- a/tests_scripts/accounts/accounts.py
+++ b/tests_scripts/accounts/accounts.py
@@ -233,9 +233,9 @@ class Accounts(base_test.BaseTest):
         Get and validate cspm link.
         Returns tuple of (stack_link, external_id) strings.
         """
-        stack_response = self.backend.get_cspm_link(region=region, external_id=True)
-        stack_link = stack_response["stackLink"]
-        external_id = stack_response["externalID"]
+        data = self.backend.get_cspm_link(region=region, external_id="true")
+        stack_link = data["stackLink"]
+        external_id = data["externalID"]
 
         return stack_link, external_id
 


### PR DESCRIPTION
### **User description**
…for external_id parameter


___

### **PR Type**
Bug fix


___

### **Description**
- Change `external_id` parameter from boolean `True` to string `"true"`

- Fix parameter type mismatch in CSPM link retrieval


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_and_validate_cspm_link_with_external_id"] --> B["get_cspm_link method call"]
  B --> C["external_id parameter"]
  C --> D["Changed from True to 'true'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>accounts.py</strong><dd><code>Fix external_id parameter type in CSPM method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/accounts/accounts.py

<ul><li>Modified <code>get_cspm_link</code> call to use string <code>"true"</code> instead of boolean <br><code>True</code><br> <li> Updated parameter type for <code>external_id</code> in CSPM link validation method</ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/704/files#diff-f9a314ed1baf8757da6d9d76f5b3b32e1584e92d7584980c08617f9a826755d4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

