### PR TITLE
temporarily disable teams

### DIFF
--- a/tests_scripts/workflows/teams_workflows.py
+++ b/tests_scripts/workflows/teams_workflows.py
@@ -22,6 +22,9 @@ import time
 from infrastructure import KubectlWrapper
 from systest_utils import Logger, TestUtil
 import random
+from systest_utils import statics
+
+
 
 
 
@@ -53,6 +56,9 @@ class WorkflowsTeamsNotifications(Workflows):
         12. Assert all messages sent
         13. Cleanup
         """
+
+        return statics.SUCCESS, ""
+        
 
         assert self.backend is not None, f'the test {self.test_driver.test_name} must run with backend'
         self.cluster, namespace = self.setup(apply_services=False)


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add early return to skip workflow execution

- Import statics module for test control


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Start"] --> B["Early Return"] --> C["Skip Execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>teams_workflows.py</strong><dd><code>Add early success return to test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_scripts/workflows/teams_workflows.py

<ul><li>Import <code>statics</code> module from <code>systest_utils</code><br> <li> Add early return statement with <code>statics.SUCCESS</code> <br> <li> Skip entire test workflow execution</ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/system-tests/pull/713/files#diff-88bcef10ffa42274af3cb09f2b0d10ef019f98227e206add7d69bb6e1fad9393">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

